### PR TITLE
Change "tool" imports to use full qiskit path

### DIFF
--- a/1_introduction/compiling_and_running.ipynb
+++ b/1_introduction/compiling_and_running.ipynb
@@ -369,7 +369,7 @@
     "\n",
     "Here we provided another example which is the Quantum Fourier transform. These can be loaded directly by using \n",
     "\n",
-    "```import tools.qi as qi```"
+    "```import qiskit.tools.qi as qi```"
    ]
   },
   {

--- a/2_quantum_information/repetition_code.ipynb
+++ b/2_quantum_information/repetition_code.ipynb
@@ -95,7 +95,7 @@
     "from qiskit import QuantumProgram\n",
     "import Qconfig\n",
     "# for visualization\n",
-    "from tools.visualization import plot_state"
+    "from qiskit.tools.visualization import plot_state"
    ]
   },
   {


### PR DESCRIPTION
Change lines that import tools via `import tools....` in order to use `import qiskit.tools....`, avoiding the symlink.