### PR TITLE
Fixed broken links and global phases

### DIFF
--- a/1_introduction/compiling_and_running.ipynb
+++ b/1_introduction/compiling_and_running.ipynb
@@ -71,9 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -140,9 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -170,9 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -224,9 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -258,9 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -310,9 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -406,9 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -459,9 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -489,9 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -552,9 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -601,9 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -653,9 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -670,7 +646,7 @@
    ],
    "source": [
     "# Place the qubits on a linear segment of the ibmqx3\n",
-    "coupling_map = {0: [1], 1: [2], 2: [3], 3: [14], 4: [3], 4: [5], 6: [7, 11], 7: [10], 8: [7], 9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 14]}\n",
+    "coupling_map = {0: [1], 1: [2], 2: [3], 3: [14], 4: [3, 5], 6: [7, 11], 7: [10], 8: [7], 9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 14]}\n",
     "initial_layout={(\"q\", 0): (\"q\", 0), (\"q\", 1): (\"q\", 1), (\"q\", 2): (\"q\", 2)}\n",
     "result3 = qp.execute([\"qft3\"], backend=\"local_qasm_simulator\", coupling_map=coupling_map, initial_layout=initial_layout)\n",
     "result3.get_counts(\"qft3\")"
@@ -686,9 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -749,9 +723,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python QISKitenv",
    "language": "python",
-   "name": "python3"
+   "name": "qiskitenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -763,7 +737,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/1_introduction/quantum_gates_and_linear_algebra.ipynb
+++ b/1_introduction/quantum_gates_and_linear_algebra.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Quantum Gates \n",
     "\n",
-    "Quantum gates on $q$ qubits can be regarded as unitary operations rotating a complex vector of dimension $2^q$, that corresponds to the quantum state. This tutorial is written to list elementary gates and their corresponding unitary matrices. Each gate is documented in [the openqasm](https://github.com/QISKit/openqasm/blob/master/spec/qasm2.pdf). The gates are defined in [the file `qelib1.inc`](https://github.com/QISKit/openqasm/blob/master/examples/generic/qelib1.inc), and implemented in [the standard extension](https://github.com/QISKit/qiskit-sdk-py/tree/master/qiskit/extensions/standard). The gates can be divided into one-qubit gates and multi-qubit gates. \n",
+    "Quantum gates on $q$ qubits can be regarded as unitary operations rotating a complex vector of dimension $2^q$, that corresponds to the quantum state. This tutorial is written to list elementary gates and their corresponding unitary matrices. Each gate is documented in [the openqasm](https://github.com/QISKit/openqasm/blob/master/spec-human/qasm2.pdf). The gates are defined in [the file `qelib1.inc`](https://github.com/QISKit/openqasm/blob/master/examples/generic/qelib1.inc), and implemented in [the standard extension](https://github.com/QISKit/qiskit-sdk-py/tree/master/qiskit/extensions/standard). The gates can be divided into one-qubit gates and multi-qubit gates. \n",
     "\n",
     "In the hereafter, following the standard in the quantum community we treat the order of the qubits from left to right, namely, the least significant bit (LSB) is the left-most qubit. Thus, the tensor product of $q_0$, $q_1$, and $q_2$ of the three qubits is defined as $q_0 \\otimes q_1 \\otimes q_2$. \n",
     "\n",
@@ -37,10 +37,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Checking the version of PYTHON; we only support > 3.5\n",
@@ -89,19 +87,26 @@
     "The bit-flip gate $X$ is defined as:\n",
     "\n",
     "$$\n",
-    "X = u3(\\pi, 0, pi) = \n",
+    "X \\equiv u3(\\pi, 0, \\pi)  = \n",
+    "-i\n",
     "\\begin{pmatrix}\n",
     "0 & 1\\\\\n",
     "1 & 0\n",
     "\\end{pmatrix}\n",
+    "\\equiv \n",
+    "\\begin{pmatrix}\n",
+    "0 & 1\\\\\n",
+    "1 & 0\n",
+    "\\end{pmatrix},\n",
     "$$\n",
+    "where in the hereafter $i = \\sqrt{-1}$, and the symbol $\\equiv$ denotes the equivalence up to the global phase. \n",
     "\n",
     "#### $Y$: bit- and phase-flip gate\n",
     "\n",
     "The $Y$ gate is defined as:\n",
     "\n",
     "$$\n",
-    "Y = u3(\\pi, \\pi/2, \\pi/2) = \n",
+    "Y \\equiv u3(\\pi, \\pi/2, \\pi/2) = \n",
     "\\begin{pmatrix}\n",
     "0 & -i\\\\\n",
     "i & 0\n",
@@ -126,9 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -169,9 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -208,7 +209,7 @@
     "\\end{pmatrix}.\n",
     "$$\n",
     "\n",
-    "Notice that the above unitaries are essentially equivalent to $e^{-i{(\\phi + \\lambda)}/{2}} u3(\\theta, \\phi, \\lambda)$, as in Eq.(2) of the openqasm [here](https://github.com/QISKit/openqasm/blob/master/spec/qasm2.pdf). \n",
+    "Notice that the above unitaries are essentially equivalent to $e^{-i{(\\phi + \\lambda)}/{2}} u3(\\theta, \\phi, \\lambda)$, as in Eq.(2) of the openqasm [here](https://github.com/QISKit/openqasm/blob/master/spec-human/qasm2.pdf). \n",
     "\n",
     "Here is the command to add such a $u3$ gate to a circuit.  "
    ]
@@ -216,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -249,7 +248,7 @@
     "$u2(\\phi, \\lambda)$ gates are rotations of 1-qubit state whose mathematical definitions are:\n",
     "\n",
     "$$\n",
-    "u2(\\phi, \\lambda) = u3(\\pi/2, \\phi, \\lambda) = \n",
+    "u2(\\phi, \\lambda) \\equiv u3(\\pi/2, \\phi, \\lambda) = \n",
     "\\frac{1}{\\sqrt{2}} \\begin{pmatrix}\n",
     "1 & -e^{i\\lambda} \\\\\n",
     "e^{i\\phi} & e^{i(\\phi + \\lambda)}\n",
@@ -262,9 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -305,9 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -368,9 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -419,9 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -450,7 +441,7 @@
     "#### Rotation around X-axis\n",
     "\n",
     "$$\n",
-    "R_x(\\theta) = u3(\\theta, -\\pi/2, \\pi/2) = \n",
+    "R_x(\\theta) = u3(\\theta, -\\pi/2, \\pi/2) \\equiv \n",
     "\\begin{pmatrix}\n",
     "\\cos(\\theta/2) & -i\\sin(\\theta/2)\\\\\n",
     "-i\\sin(\\theta/2) & \\cos(\\theta/2).\n",
@@ -460,7 +451,7 @@
     "#### Rotation round Y-axis\n",
     "\n",
     "$$\n",
-    "R_y(\\theta) = u3(\\theta, 0, 0) = \n",
+    "R_y(\\theta) = u3(\\theta, 0, 0) \\equiv\n",
     "\\begin{pmatrix}\n",
     "\\cos(\\theta/2) & \\sin(\\theta/2)\\\\\n",
     "\\sin(\\theta/2) & \\cos(\\theta/2).\n",
@@ -483,9 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -575,9 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -636,12 +623,12 @@
     "Perform controlled-$U$ rotation on the target qubit if the control qubit is $1$. \n",
     "\n",
     "$$\n",
-    "C_{u3}(\\theta, \\phi, \\lambda) = \n",
+    "C_{u3}(\\theta, \\phi, \\lambda) \\equiv \n",
     "\\begin{pmatrix}\n",
     "1 & 0 & 0 & 0\\\\\n",
     "0 & 1 & 0 & 0\\\\\n",
-    "0 & 0 & \\cos(\\theta/2) & -e^{i\\lambda}\\sin(\\theta/2)\\\\\n",
-    "0 & 0 & e^{i\\phi}\\sin(\\theta/2) & e^{i(\\phi + \\lambda)}\\cos(\\theta/2)\n",
+    "0 & 0 & e^{-i(\\phi+\\lambda)/2}\\cos(\\theta/2) & -e^{-i(\\phi-\\lambda)/2}\\sin(\\theta/2)\\\\\n",
+    "0 & 0 & e^{i(\\phi-\\lambda)/2}\\sin(\\theta/2) & e^{i(\\phi+\\lambda)/2}\\cos(\\theta/2)\n",
     "\\end{pmatrix}.\n",
     "$$\n",
     "\n",
@@ -651,9 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -694,9 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -757,9 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -778,6 +759,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Remark on the equivalence of gates up to the global phase \n",
+    "\n",
+    "In the above we see that the one-qubit $X$ gate is equivalent to the $u3(\\pi, 0, \\pi)$ gate up to the global phase, but the global phase can be tricky with controlled gates. For example, the $C_X$ gate (or, the control NOT gate) is not equivalent to the $C_{u3}(\\pi, 0, \\pi)$ gate. This is because:\n",
+    "\n",
+    "$$\n",
+    "C_{u3}(\\pi, 0, \\pi) \\equiv \n",
+    "\\begin{pmatrix}\n",
+    "1 & 0 & 0 & 0\\\\\n",
+    "0 & 1 & 0 & 0\\\\\n",
+    "0 & 0 & 0 & -j\\\\\n",
+    "0 & 0 & -j & 0\n",
+    "\\end{pmatrix} \\neq \n",
+    "\\begin{pmatrix}\n",
+    "1 & 0 & 0 & 0\\\\\n",
+    "0 & 1 & 0 & 0\\\\\n",
+    "0 & 0 & 0 & 1\\\\\n",
+    "0 & 0 & 1 & 0\n",
+    "\\end{pmatrix} = C_X\n",
+    "$$ "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -790,9 +798,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python QISKitenv",
    "language": "python",
-   "name": "python3"
+   "name": "qiskitenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -804,7 +812,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed broken links to `qasm2.pdf`. Fixed global phase of cu3. Added explanation of the equivalance of gates up to the global phase emphasizing CX (control not) is not equivalent to cu3(pi, 0, pi). 

Thanks to @yoonbo for initiating the discussion that leads to this fixing. 