### PR TITLE
Link fix in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ directly run those using DSx. To get started, refer to this
 example: `1_introduction/running_on_IBM_DSX.ipynb`
 
 See this `link
-<https://github.com/qiskit-tutorial/wiki/Running-Quantum-Program-on-IBM-DSx>`__ 
+<https://github.com/QISKit/qiskit-tutorial/wiki/Running-Quantum-Program-on-IBM-DSx>`__ 
 that gives step-by-step instructions on setting up an example notebook on DSx. 
 
 Other QISKit projects


### PR DESCRIPTION
Fixed link in "Using IBM DSx for your notebooks" section.