### PR TITLE
Fix name of circuit

### DIFF
--- a/1_introduction/getting_started.ipynb
+++ b/1_introduction/getting_started.ipynb
@@ -94,7 +94,7 @@
     "# Creating Circuits\n",
     "# create your first Quantum Circuit called \"qc\" involving your Quantum Register \"qr\"\n",
     "# and your Classical Register \"cr\"\n",
-    "qc = qp.create_circuit('qc', [qr], [cr])"
+    "qc = qp.create_circuit('Circuit', [qr], [cr])"
    ]
   },
   {


### PR DESCRIPTION
qp.create_circuit should create a circuit named 'Circuit' instead of 'qc'. In other parts of the notebook it is called as 'Circuit'.

This notebook doesn't work as it is now.