### PR TITLE
Add environment variable import for API token and example Qconfig to stable

### DIFF
--- a/1_introduction/example_Qconfig.py
+++ b/1_introduction/example_Qconfig.py
@@ -27,9 +27,3 @@ config = {"url": "https://quantumexperience.ng.bluemix.net/api"}
 
 if APItoken is None:
     raise Exception("Please set up your access token. See Qconfig.py.")
-
-if config is None:
-    raise Exception("Please set up your config parameters. See Qconfig.py")
-
-if __name__ == "__main__":
-    pass

--- a/1_introduction/example_Qconfig.py
+++ b/1_introduction/example_Qconfig.py
@@ -1,0 +1,35 @@
+"""An example Qconfig file you can customize.
+
+Set your configuration parameters to be imported into the notebooks.
+
+The APIToken can be set as an environment variable in your shell session. For
+example, in your ~/.bash_profile or ~/.bashrc add:
+
+.. code-block:: bash
+
+    export IBMQE_API="your_secret_api_string"
+
+and restart your terminal session. This will add the ``$IBMQE_API`` as an
+environment variable that can be accessed by the script.
+
+Once imported, you can check the values have set using print:
+
+.. code-block:: python
+
+    import Qconfig
+    print(Qconfig.APItoken, Qconfig.config['url'])
+
+"""
+import os
+
+APItoken = os.getenv("IBMQE_API")  # change to match your variable name if needed
+config = {"url": "https://quantumexperience.ng.bluemix.net/api"}
+
+if APItoken is None:
+    raise Exception("Please set up your access token. See Qconfig.py.")
+
+if config is None:
+    raise Exception("Please set up your config parameters. See Qconfig.py")
+
+if __name__ == "__main__":
+    pass

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,22 @@ Briefly, the steps are:
             if 'APItoken' not in locals():
                 raise Exception('Please set up your access token. See Qconfig.py.')
 
+    4. Alternatively, you can set your API token in an environment variable for your
+       shell session and import it into the ``Qconfig.py`` file using ``os``.
+       For example:
+
+       .. code:: python
+
+           import os
+           APItoken = os.getenv('your_API_token_environment_variable')
+           config = {'url': 'https://quantumexperience.ng.bluemix.net/api'}
+
+           if APItoken is None:
+               raise Exception('Please set up your access token. See Qconfig.py.')
+
+        An example ``Qconfig.py`` file has been included in the introduction
+        notebook folder.
+
 2. Install `Jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -86,7 +102,7 @@ Then install jupyter with,
 
 Using ``git`` to clone the SDK repository is the easiest way to
 keep up with the latest changes or to contribute to the
-tutorials. 
+tutorials.
 
 .. code:: sh
 
@@ -174,24 +190,24 @@ tutorial.
 
 Using IBM DSx for your notebooks
 ---------------------------------
-IBM Data Science Experience (DSx) is a platform where you can interactively 
-run your quantum programs, collaborate and share your work with others. 
+IBM Data Science Experience (DSx) is a platform where you can interactively
+run your quantum programs, collaborate and share your work with others.
 
-Among other things, it provides a ready-to-use environment to run Jupyter 
-Python notebooks. For someone just getting started with QISkit, this is an 
-excellent option. You can skip all the installation and environment creation 
-steps on your computer, and instead use this web-hosted Jupyter notebook 
-environment for running the Quantum programs. It also provides a platform 
-where you can invite fellow researchers to collaborate on the notebooks 
+Among other things, it provides a ready-to-use environment to run Jupyter
+Python notebooks. For someone just getting started with QISkit, this is an
+excellent option. You can skip all the installation and environment creation
+steps on your computer, and instead use this web-hosted Jupyter notebook
+environment for running the Quantum programs. It also provides a platform
+where you can invite fellow researchers to collaborate on the notebooks
 you have developed or simply share your work within the community.
 
-We have customized the example notebooks for you, so that you can 
-directly run those using DSx. To get started, refer to this 
+We have customized the example notebooks for you, so that you can
+directly run those using DSx. To get started, refer to this
 example: `1_introduction/running_on_IBM_DSX.ipynb`
 
 See this `link
-<https://github.com/QISKit/qiskit-tutorial/wiki/Running-Quantum-Program-on-IBM-DSx>`__ 
-that gives step-by-step instructions on setting up an example notebook on DSx. 
+<https://github.com/QISKit/qiskit-tutorial/wiki/Running-Quantum-Program-on-IBM-DSx>`__
+that gives step-by-step instructions on setting up an example notebook on DSx.
 
 Other QISKit projects
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -77,8 +77,8 @@ Briefly, the steps are:
            if APItoken is None:
                raise Exception('Please set up your access token. See Qconfig.py.')
 
-        An example ``Qconfig.py`` file has been included in the introduction
-        notebook folder.
+      An example ``Qconfig.py`` file has been included in the introduction
+      notebook folder.
 
 2. Install `Jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -227,7 +227,9 @@ Other QISKit projects
 Contributors (alphabetically)
 -----------------------------
 
-Jerry Chow, Antonio Córcoles, Abigail Cross, Andrew Cross, Ismael Faro, Andreas Fuhrer, Jay M. Gambetta, Takashi Imamichi, Antonio Mezzacapo, Ramis Movassagh, Anna Phan, Rudy Raymond, Ninad Sathaye, Kristan Temme, Chris Wood, James Wootton.
+Jerry Chow, Antonio Córcoles, Abigail Cross, Andrew Cross, Ismael Faro, Andreas Fuhrer,
+Jay M. Gambetta, Takashi Imamichi, Evan Kepner, Antonio Mezzacapo, Ramis Movassagh, Anna Phan, Rudy Raymond, 
+Ninad Sathaye, Kristan Temme, Chris Wood, James Wootton.
 
 In future updates anyone who contributes to the tutorials can include their name here.
 


### PR DESCRIPTION
Hi - in reference to the discussion on #74 I've added the following changes to the stable branch for review:

- Added alternative configuration to the README explaining how to use `os` for importing an environment variable from the shell session.
- Added an `example_Qconfig.py` to the introduction folder that can be customized. It will raise an exception if the user does not set an environment variable or has an unset config dictionary.
- Added my name alphabetically to the contributors list.

Thanks for considering this!