### PR TITLE
fix relaxation notebook with barriers

### DIFF
--- a/3_qcvv/relaxation_and_decoherence.ipynb
+++ b/3_qcvv/relaxation_and_decoherence.ipynb
@@ -2,20 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "<img src=\"../images/QISKit-c.gif\" alt=\"Note: In order for images to show up in this jupyter notebook you need to select File => Trusted Notebook\" width=\"250 px\" align=\"left\">"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## _*Relaxation and Decoherence*_ \n",
     "\n",
@@ -28,10 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Introduction\n",
     "\n",
@@ -44,11 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -67,11 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -79,17 +66,16 @@
     "def pad_QId(circuit,N,qr):\n",
     "    # circuit to add to, N= number of QId gates to add, qr=qubit reg\n",
     "    for ii in range(N):\n",
+    "        circuit.barrier(qr)\n",
     "        circuit.iden(qr)\n",
     "    return circuit    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -104,10 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Measurement of $T_1$\n",
     "\n",
@@ -118,11 +101,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -160,23 +141,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running on backend: ibmqx4\n",
-      "status = RUNNING (20 seconds)\n",
-      "status = RUNNING (40 seconds)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run the program on hardware/simulator\n",
     "result=Q_program.execute(circuits, backend=backend, shots=shots, wait=20, timeout=600)"
@@ -184,33 +153,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAExCAYAAABbFFT9AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl4VOX1wPHvSUggEPYtgGhQQREpYNyqbFpQC6hYFyyK\nWJHV4k9pbW3dUOu+K6KIKIIoLqi4oaglSEHZFAyCooAoIIugQIAQQs7vj/eGDEOWSTIzN5k5n+eZ\nh8ydu5yXSebMfVdRVYwxxpiKSvA7AGOMMbHBEooxxpiwsIRijDEmLCyhGGOMCQtLKMYYY8LCEoox\nxpiwsIRijDEmLCyhGGOMCQtLKMaYSkdEWonIWyKyRURURCb6HZMpXTW/AzCRIyJlmQahlar+EKlY\nTGwRkY5AX2BihH5vJgK/A+4CNgKrQoipDvB/wAVAayAR+AF4F3hQVTdHIE4TQGzqldglIpcHbeoC\nDAGeAeYEvfamqu6KSmCmyhORK4HngTNUNTPM564O7AHGqOq1IR7TBvgQOAJ4A5gF7ANOBS4HtgN9\nVHV+OGM1B7M7lBimqi8GPheRariE8lnwayYyRCQRqK6qu/2OpQppCgiwLZSdRaQm8A7QAjhXVd8L\nePkZERkLfAy8LSLt7U4lcqwNxUSMiFzp1X//QURuFZG1IrJHROaLyKnePt1E5H8isktEfhaRW4o4\nT3UR+beIfC0iOSLym4i8IyKdgvarLSL/8c7/i4jsFZHvReRe70MncN8aIjJaRL4Vkd3eObNE5IGg\n/UZ7ZUgvIq4fRCSziPL2EJFbRGQVkANcUpZy+PR/V3C9M0Xk7yKyyvv/WykiA4P/T3B3JwCzvONK\nbecQkUYi8qSI/CQiud6/T4pIw4B9JgJrvae3BZy7ewmnHgS0AR4JSiYAqOoi4N9AE+CGkmI0FWN3\nKCYa7sXVZz8GJAN/Az70Pqgm4KrgpuA+eO8QkTUFd1AikgR8AJwGTAbGAHWBwcBcEenqfWCA+4Z6\nNTANeAnIA7oB/wA6AWcHxPQkcBUwCXjEi681cGYYyvsgkASMB3YA35axHIGi9X9X4G4gBRgH7AWG\nAxNF5HtVnevt8wbQDHe3ezewwttebDuHiNQF5gFHA88BX+Dek+HAmSJysqru9K67BPeevOldi4Br\nFOUi79/xJewzEXgUuBBLKpGjqvaIkwdwJaDAlVG+3hdAcsD287ztecBJAduTgZ9xVXIF26739j07\n6Nx1gB+BzKDjk4qI407vHCcHbNsGvB9CGUZ7x6YX8doPQdcvKO+3QM2gfUMuh0//dwXX+zLoei1w\nieXlYuLrHuLvwl3e/iOCtl/jbb8zYFu6t210iOfeCuwIYb8s77yp0fj9j8eHVXmZaHhKVXMDnhd0\nCPhcVRcWbPT2WYC7UyhwOfANsNirMmkkIo1wH6AfAZ1FJKXgeFXdB669SETqe/t+7J3rlIDzbgfa\nicjx4SvmAU/poW0mIZejiHNF/P8uwNjA66nqemBl0HnL4wJgC+6OKtA44Bfv9fKqg3s/S1OwT+0K\nXMuUwKq8zAEicglwLdAR+EVV08N06tWBT1T1VxEBWFPEvr8CDQOet8VVwWwp4fyNgJ8ARGQEMAxo\nx6FthPUDfr4OVw2UJSKrcb2C3gHeUdX8UspTmpVFbCtTOQJE7f+uqOt5tuJ6T1VEK2CRquYFblTV\nPBH5FjihAufegUsqpakD5OMSGADiGuzPxVUF7gReA/4RlMRNiCyhmEC/4urZm+KqS8Jlfxm3BxJc\nVcWoEvbZAiAio4CHgJnA48AGIBdXbTORgASjqtO9hvZeuHaWHrjG3Tki0iPgA6WkfvXF/f0U1aMr\n5HIEicr/XQjnlRCu55dlQFcROVpVvy9qB69TxjHA2oK7WM8Y4AZV3SUijYFXcQ34oyMcc0yyhGIO\nUNWPAESkr9+xBPgOaAz8N4Q7hwG4do0/Bu4rIucUtbOqbgNeBF4U97X/XlwD/vm4b6pQ2HW1gXfu\ngnPWwDVMF/kBVsFyhEskr1nWAWyrgWNEpFrgXYq4ruxtKPrOKFTTgK64Dhk3FrPPFbiqvoO6y6vq\n8qD98ql49V7csjYUU9lNAtIo5lu2iDQNeLof90EnAa9XI+hDRkQSRaRe4DZ1rbZfek8bBLxUUH3V\nI+jS11O2v5+ylCNcInnNbO/fBiXuVegtXHK7Omj7YG/7mxWI5Vnc+3R9UV8eROQE4B5cp4Uni3j9\nRhHJBjYDHXC9wUw52B2KqeweA3oCD4jImcB/cXXmhwN/wI3zOMPb93XcB8cMEXkDV2feHzdiOlBt\n4GcReRuXRDbj6viH46r93gnY92Ncw/Yd3niJNUBn3AjsXwhdWcoRLpG85kLct/mbRKQ+sAtYo8WP\nRL8fuBh40vuA/xLXbXgQrlfc/eWMA1XdLSLn4bpIvyci04BMXE+4k3F3rr8C56nqpiKOvxe4V0Ta\nApfhEo8pB0soplJT1X0i0hsYgftguN17aQOuV9MLAbs/gLs7GYT7MN0IvIIbhBdYtbEb9y30D7g7\nj1Tch8jbwD2quiHg+vtF5Hxcm8xIXJvMTFy7y1xCVMZyhEUkr6mqP4rIVcA/gadw425eAIpMKKq6\nXURO92I4D/gLsAl4GrhN3RiUclPVb0WkA24urz/h2sZqeS9/DXRW1d9KOccKEVmK66wR7uQeF2wu\nL3MIrw3l0TD28jIm6rzqztdwk1j+TVUfDuGY/sADqtoi0vHFImtDMQd4bQs1cN82Rdz0JNX9jsuY\n8vAa//sB7wMPicjwwNdFpK435Uw9cdoDN+MmmTTlYHco5gApnEE20Fq7UzGxSNx092/gxsAk49rS\n3sBVwdnM2+VgCcUYY0xYWJWXMcaYsLCEYowxJixiuttwo0aNND09vdzH79q1i1q1apW+Ywyyssdn\n2SG+yx/PZYfC8i9evPgXVW1c1uNjOqGkp6ezaFFRS0yEJjMzk+7du4cvoCrEyt7d7zB8E8/lj+ey\nQ2H5RWRt6Xsfyqq8jDHGhIUlFGOMMWFhCcUYY0xYWEIxxhgTFjHdKG+MqZj8/Hx++eUXfvvtN/bv\nD2VNr6qtbt26rFixwu8woqJGjRocdthhJCUlhe2cllCMMcVat24dIkJ6ejpJSUl4yw/HrJ07d1K7\nduwvOa+qbN26lXXr1tGqVauwndeqvIwxxdq1axctWrQgOTk55pNJPBERGjZsSE5OTljPawnFGFOi\nhAT7mIhFkfiCYFVexTjtNNiyJYM5cyAtze9ojDGm8rOvHkWYPBnmz4fVq2tx5JHuuTHGmJJZQgmy\ncSMMHQr5+ZCfn8CePe75xo1+R2aMMZWbJZQga9ZAcC+65GS33RhTuaSmph54JCQkkJKScuD5lClT\nInrtyy+/nGbNmlGnTh3atGnDs88+e+C1vXv3MmjQII444ghq165Np06dmDFjRrHn2rZtGxdccAG1\natXiiCOO4KWXXopo7JFibShBWrWCffsO3pabs59WrRL9CcgYU6zs7OwDP6enp/Pss8/So0ePqFz7\nX//6FxMmTKB69ep88803dO/enU6dOpGRkUFeXh4tW7Zk9uzZHH744bz//vtccsklZGVlUdQM6Ndc\ncw3Jycls2rSJJUuW0Lt3bzp06EC7du2iUpZwsTuUIGlpMG4cpKRArZr7SJEcxjGMtE1L/Q7NGFOJ\ntGvXjurVqwOux5SIsGrVKgBq1arF6NGjSU9PJyEhgT59+tCqVSsWL158yHl27drFtGnTuPPOO0lN\nTaVz586cd955TC6h8fauu+5i+PDhB57/+uuvJCUlkZOTw3333UeLFi2oXbs2xxxzDJ988kmYS148\nXxKKiIwQkTUikiMii0WkSyn7XyMiK0Rkj4h8KyJXRDK+AQNg9Wq47/4sVi/axoDGH8ADD0TyksYY\nn/Tp04d69epRr149WrZseeDnevXq0adPnxKPHTFiBDVr1uTYY4+lWbNm9OrVq8j9Nm3axMqVK4u8\n41i5ciWJiYm0adPmwLYOHTrw9ddfF3vdrKwsOnbseOD5kiVLOOaYY1i7di1jxoxh4cKF7Ny5kw8/\n/LDIO6JIiXqVl4j0Ax4DRgD/8/6dISLHqeqPRew/HLgPGAzMB04GxovIr6r6TqTiTEuDdu12kHbC\nCfDpp9CiRaQuZUzVUtR6IZdcAiNGwO7dUNSH6pVXuscvv8BFFx36+vDh0K8f/PQTtGwZljC3b99O\nz549Wb58OZ9//jnHH398kfu9++67B34u60j5sWPH8sQTT/DZZ5+RmZl54I4l0L59+7jssssYOHAg\nxx577CGvZ2dnU7du3YO21a1bl507dxZ73aysLK6//voDz5csWUKHDh1ITExk7969LF++nMaNG0c1\nmYA/dyijgImqOl5VV6jqSOBnYHgx+w8Axqvqy6q6WlWnAs8A/4xSvK5hJTkZtm6Fa6+FPXuidmlj\nTPnUrFmT9957j4uKSmBhlJiYSOfOnVm3bh1PPfXUQa/l5+czYMAAkpOTGTNmTJHHp6amsmPHjoO2\n7dixo9jElpuby6pVq2jfvv2BbUuXLqVjx44cffTRPProo4wePZomTZpw6aWXsmHDhgqWMHRRvUMR\nkWQgA3gw6KWZwGnFHFYdCJ4fYA9wsogkqeq+Io6JjM8+gzFjYN06eO01SLSGehOHMjOLf61mzZJf\nb9So5NfDdHcCkJSUROPGpa9i+8c//pE5c+YU+VqXLl1K7J0VKC8v70AbCrj5sgYNGsSmTZt4//33\ni52EsU2bNuTl5fHdd9/RunVrwCWI4hrkly9fTosWLahZs+aB62RmZtK/f38A+vfvT//+/dmxYwdD\nhw7ln//8Z4ntMeEU7SqvRkAisClo+yaguK4ZHwKDROQNYBEuIV0NJHnn+zlwZxEZAgwBaNq0KZkl\n/fKWIjs7++DjU1Npcc01tB4zhvUXXcR3114LMTq/0SFljyPxXHY4uPylVb1UJqrK7t27D4l33759\n7Nq1q9hyvPrqqwd+3r9/P4lBXxSLOm7Lli3Mnj2bc845h5SUFGbNmsXLL7/MhAkTDux/3XXXsWzZ\nMt5++23y8vJK/H8899xz+de//sWYMWPIyspi+vTpfPTRR0Ues2DBAjZv3szSpUtp1qwZDzzwAGvX\nrqVRo0Z88cUXbNiwgVNPPRURoVq1auTn5xd77ZycnIN+1yv8u6+qUXsAzQEFugRtvw34pphjUoDn\ngH1AHrAe16aiQJOSrpeRkaEVMWvWrKJfuOEGVVC9994Knb8yK7bscSCey656cPmXL1/uXyBldMQR\nR+hHH310yPaBAwdqVlZWSOfYsWNHSPtt3rxZu3btqnXr1tXatWvr8ccfr88888yB13/44QcFtHr1\n6lqrVq0DjxdffPHAPuecc47eddddqqq6detWPf/887VmzZrasmVLnTJlSrHXvuGGG/TCCy/U1q1b\na/PmzfXxxx/XI488Uq+44gpdunSpnnTSSZqamqr169fX3r176/r164s9V/D7W/DeA4u0HJ/x0b5D\n+QXYDwTPjtWEQ+9aAFDVPcBVIjIUaIq7IxkC7PTOF3333gvr18Mzz8Bf/wq1avkShjGm0A8//BC1\nazVu3JjZs2cX+/oRRxxR8IW4WIFVaQ0aNOCtt94K6dpZWVlcffXVvP766we2jRw58sDPCxYsCOk8\nkRDVRnlVzQUWAz2DXuoJzCvl2H2quk5V9wOXAu+qan5kIi1FQgI8/7xrU7FkYkyl1atXL2bOnMng\nwYOZOHGi3+GERVZWFm3btvU7jCL5MVL+YWCyiCwA5gLDcFVhTwOIyCQAVb3Ce94GOAX4HKiP6yV2\nPDAw6pEHSk6GJk3csPpRo+Cqq6BTJ19DMsYc7P333/c7hLD69ddf2bx584HG+8om6glFVV8RkYbA\nzUAzYBnQS1XXerscHnRIIi6JHINrR5kFnKaqP0Qn4lJs2wZvvw2vvw7z5rkuxsYYEwH169cnNzfX\n7zCK5ctcXqo6FhhbzGvdg56vACrvV/+mTeGDD+D00+Gcc2DuXNc10hhj4ozN5RUObdu6u5S1a+G8\n89xoYWOMiTOWUMKlc2d46SX4+mv3MMaYOGPT14fTn/7k5jlq0MDvSIwJG1WNyPrjxl+ldWsuD7tD\nCbeCZPLEE3DPPf7GYkwFJSUlscfmrotJ+/bto1q18N5TWEKJBFVYsAD+/W+Ikb7vJj41adKE9evX\ns3v37oh8ozX+yM/PZ9OmTYfMclxRVuUVCSIwYYJbiP7qq91c+Oec43dUxpRZnTp1ANiwYQP7gpcy\njUE5OTnUqFHD7zCiolatWjQKc49USyiRkpwM06ZBt25u/YfZsyEjw++ojCmzOnXqHEgssS4zM5NO\nNkC53KzKK5Lq1IH333cj6n2cX8cYY6LB7lAirVkzyMoqnPNLNWanvDfGxDe7Q4mGgmTy3/+6thQb\n+GiMiUGWUKJpxw74+GO49FLIy/M7GmOMCStLKNHUty88+SS88w6MGOGqv4wxJkZYG0q0DRvm1qS/\n6y63fvYtt/gdkTHGhIUlFD/ceadLKitXWiO9MSZmWELxgwg8+ywkJrqf8/PdKpDGGFOF2aeYX6pV\nc8lkzRo34HHhQr8jMsaYCrGE4reaNWH7dujdG77/3u9ojDGm3Cyh+K1gxcf8fDdGZfNmvyMyxphy\nsYRSGbRpA+++Cxs2uDuV7Gy/IzLGmDKzhFJZnHoqvPIKJCVBTo7f0RhjTJlZQqlMzj0X/vc/aNTI\njaS3gY/GmCrEEkplk5Dg7lD69IHRo/2OxhhjQuZLQhGRESKyRkRyRGSxiHQpZf/+IrJERHaLyEYR\neVFE0qIVb9RVrw4tWsAdd/Bgm2f8jsYYY0IS9YQiIv2Ax4C7gU7APGCGiBxezP6nA5OBF4B2QF/g\nOGBKVAL2gwg8/TTv1evPqd+9wMaxb/gdkTHGlMqPO5RRwERVHa+qK1R1JPAzMLyY/X8PrFPVR1R1\njap+DjwBnBKleH0xeWoS5+14kXP4kCOvOYfJQ//nd0jGGFOiqCYUEUkGMoCZQS/NBE4r5rC5QDMR\nOVecRsClwPuRi9RfGzfC0KGQny/sIpU91GToC6excaPfkRljTPGifYfSCEgENgVt3wQU2Saiqp8B\nf8ZVceUCWwABBkYuTH+tWeN6DwdKrpHAmtUKH31kvb+MMZWSX5NDBn8iShHb3AsixwGPA3cCHwLN\ngAeAccAVRew/BBgC0LRpUzIzM8sdZHZ2doWOL69t25LZu/cUXO51cnL2kzP9cbh/FD/268fqoUMj\nOkuxX2WvDOK57BDf5Y/nskMYyq+qUXsAyUAecHHQ9ieB2cUcMxl4M2hbZ1wCalnS9TIyMrQiZs2a\nVaHjK2LSJNWEBNXERNWUFPdc9+9XHTFCFVSHDXPPI8TPsvstnsuuGt/lj+eyqxaWH1ik5fiMj+od\niqrmishioCfwWsBLPYFpxRxWE9gftK3gecwuJDJgADz1FOzZAzNmQFoaQAKMGQO1a8N998GuXfDc\nc27mYmOM8Zkfn0QPA5NFZAGuwX0Y0Bx4GkBEJgGoakF11jvAeBEZTmGV16PAF6r6Y5Rjj6p584rY\nKAL33gt16rjVHgcPhi4lDuMxxpioiHpCUdVXRKQhcDMuOSwDeqnqWm+Xw4P2nygitYG/Ag8B24FZ\nwD+iF3Ul9O9/wwUXQNu27rmt/GiM8ZkvI+VVdayqpqtqdVXNUNVPA17rrqrdg/Z/QlXbqWpNVW2m\nqv1VdV3UA69sCpLJO+9Az56wY4e/8Rhj4prN5RULdu+G2bOhRw/Yts3vaIwxccoSSizo1w/eeAO+\n+gq6d4dNwcN8jDEm8iyhxIpzz4X33oNVq1wjvd2pGGOizPqbxpI//MGNpJ8+HerX9zsaY0ycsYQS\na047zT0Avv3WLdTVrp2/MRlj4oJVecUqVRg4ELp1g8WL/Y7GGBMHLKHEKhGYMgVSU+HMM2HuXL8j\nMsbEOEsoseyoo9wa9c2awVlnwccf+x2RMSaGWUKJdYcdBp9+Ckcf7eb/sqnvjTERYo3y8aBJE5g1\ny00iKQL5+ZBg3yWMMeFlnyrxokEDN6Hk7t2ue/H48X5HZIyJMZZQ4o0IpKTAkCHwyCN+R2OMiSGW\nUOJNSgq89RZceCGMGgV33GHtKsaYsLCEEo+Sk2HqVLjiCrjtNre+ijHGVJA1yseratXg+eehRQv4\n05/8jsYYEwPsDiWeJSTA3XfDMce4aq8XX3RTtRhjTDlYQjHOrFluIftLL4Xc3INe6t7dPYwxpiSW\nUIxz5pmu19e0aXD++STk5PgdkTGmirE2FFPouuugdm0YPJjfbdjgZi2uU4fcXNizBzZuhLQ0v4M0\nxlRWdodiDjZoEEyZQu1vv4XFi5k8GebPh6wsOPJImDzZ7wCNMZWV3aGYQ/35z8yvXp0j257B0N5u\nphZwdylDh0LPnnanYow5lN2hmCLlNmjAmjWQxMEN9MnJsGaNT0EZYyo1XxKKiIwQkTUikiMii0Wk\nSwn7ThQRLeKxK5oxx6NWrWBffuJB23Jz3XZjjAkW9YQiIv2Ax4C7gU7APGCGiBxezCH/BzQLeqwG\nXo18tPEtLQ3GjU8kUfKpzQ5S2M24v3xu1V3GmCL5cYcyCpioquNVdYWqjgR+BoYXtbOqblfVjQUP\n4CjgSMCmy42CAQPg5FMT6HT8PlafdCkDxv7etdIbY0yQqDbKi0gykAE8GPTSTOC0EE8zGPhaVeeF\nMzZTvHnzABpC7uvw+utwyinuBVtXxRgTINqfBo2ARGBT0PZNQKkVKSJSF7gYuzvxR3Iy9O/vfv7q\nK+jUyfUnNsYY/Os2HDxfuhSxrSiX4xJSsaMhRGQIMASgadOmZGZmljNEyM7OrtDxVVlpZa+9fDnH\nr1tHtZNPZsWNN/JLt27RCy7C4vl9h/gufzyXHcJQflWN2gNIBvKAi4O2PwnMDuH4JcCUUK+XkZGh\nFTFr1qwKHV+VhVT29etVTzlFFVRvukk1Ly/icUVDPL/vqvFd/nguu2ph+YFFWo7P+KhWealqLrAY\n6Bn0Uk9cb69iicjJQAesuqvyaN4cZs92o+vvugueecbviIwxPvKjyuthYLKILADmAsOA5sDTACIy\nCUBVrwg6bgjwHTA7eqGaUlWv7tanP+ccOO88t80a642JS1H/q1fVV4DrgJtxVVidgV6qutbb5XDv\ncYCI1AYuBZ71bsdMZSICF13kGu1/+QU6doTp0/2OyhgTZb58jVTVsaqarqrVVTVDVT8NeK27qnYP\n2n+nqqaq6v1RD9aUTW6uu2vp2xdGjy6cCMwYE/OsXsKEV/PmMGcODBwIt98OF1wAO3b4HZUxJgos\noZjwq1HDrVf/+OPw3nswapTfERljosCmrzeRIQIjR0KHDtC2rdu2fz8kJpZ8nDGmyrI7FBNZXbtC\n48awb59bSOU//7F2FWNiVMgJRUSSReRSbzr5b0Rkh4jkisjPIpIpIreLyHGRDNZUYXl5rn3lllvg\n4oth506/IzLGhFmpCUVEaorIbcB64EXc5I4LcAMM7wfeBPYA1wBZIjJbRE6PXMimSkpJcesHP/QQ\nvPUW/P73sGqV31EZY8IolDaUVcBG4FbgVVXdWtyOXiK5HPhQRP6mquPCE6aJCSKugf53v4N+/eCS\nS2DRIrfdGFPlhZJQhqvqW6GcTFXnAnNFZDSQXoG4TCzr0cMlkl27XDLJy3ON9ZZYjKnSSk0ooSaT\noGM2cegU9cYUClxH+NprYds2mDABatXyLyZjTIVYLy/jL1VIT4dXX4XTToM1a/yOyBhTTmFLKCKS\nISLPhet8Jk6IwD/+ATNmwI8/woknwief+B2VMaYcwnmHkg4MDOP5TDw5+2xYuBCaNYMLL4Tffjtk\nl+7d3cMYUznZSHlTeRx9NHz2mVteuF49ty03181ibIyp9EIZh7I/lAfwahTiNbGudm043RvG9PTT\ncOqpsNatbJCbC9u3w8aNPsZnjClWKHcoecBCYFYp+7UFLqhwRMYUaNnSDX488UQmD57N/PnHIQJH\nHgnjxsGAAX4HaIwJFEpCyQI2qeotJe0kIhdiCcWEU+/esGABG/tczdB70imYAWzPHhg61E0Nlpbm\na4TGmAChNMovBk4M8Xw2Ms2E1zHHsOapD0iqdvBCncnJ1sPYmMomlDuUx3Frv5fmfaBVqXsZU0at\njq/FviR1la+e3L35tGplw6iMqUxK/YtU1a9VdVII++0JWBfemLBJS4Nx44SEBDdDS0r1fMbt/Qtp\n//mrm77FGFMp2Fc8UyUMGACnnALt28PqFXsZcF1DGDvWLeA1N5QbaGNMpIXSbbjMDe0i0kxETi1f\nSMYULTkZ6taFtFYp8PDDMGuWWwWySxe4+Wa/wzMm7oVyh/KkiCwVkWEi0qCkHUWki4g8A3wP/C4s\nERrjycx0jwO6dXODIIcMceNXjDG+CqVR/mjg78AdwBMisgJYCmwB9gL1gSNxPcHqAp8CPVV1XkQi\nNiZQ7dpuAKR6vcCmT4cvv4SbboKkJH9jMybOhNIov1tV7wBa4BbPWoxbtfEq4HrgXCAReAxop6pn\nlJZMRGSEiKwRkRwRWSwiXUrZP1lE7vCO2SsiP4rItaEV0cSFgrVUMjPh9tvdCPtly3wNyZh4E/Jc\nXqq6T0Q+Aaarak55Lygi/XDJZwTwP+/fGSJynKr+WMxhLwMtgSHAd0BTIKW8MZgY9sgj0LWrG/mY\nkQF33gl/+5vrHmaMiahQGuUTRWS0iPyGWzRrh4hME5F65bzmKGCiqo5X1RWqOhL4GRhezPXPAnoA\nvVT1I1X9QVXnq2pmOa9vYt0FF8DXX0OfPvDPf7qp8Y0xERdKo/ww3HryXwAPAtOB84FHynoxEUnG\nVZfNDHppJnBaMYf1xc0lNkpE1onIdyLyuIiklvX6Jo40bgyvvw7//a+bwgUgKwvy80s+zhhTbqKq\nJe8gsgSYr6pDA7YNBcYAtVQ1N+SLiTQH1gPdVPXTgO23Apep6jFFHPMB0B34BNcxoB7wBPCVql5U\nxP5DcFVjNG3aNGPq1KmhhneI7OxsUlPjM2/FWtmrb97MyQMHsqNtW775xz/YW8IkYLFW9rKK5/LH\nc9mhsPzhj3mNAAAbzklEQVRnnHHGYlUNdcqtQqpa4gPYAfQI2lYPyAdal3Z80HHNAQW6BG2/Dfim\nmGNmAnuAugHbzvLO07Sk62VkZGhFzJo1q0LHV2UxV/b8fNXx41VTU1Vr11adMMFtK0LMlb2M4rn8\n8Vx21cLyA4u0DJ/tBY9QqrxSvaQSaKf3b1k7//8C7AeCvx42wbXPFOVnYL2qbg/YtsL79/AyXt/E\nKxG4+mpX7ZWRAYMGwXnnQV5e6ccaY0ISai+vFiJyZMDzxIDtB63VqqqrizuJquaKyGKgJ/BawEs9\ngWnFHDYXuFhEUlU129vWxvvX5g4zZZOe7tasHzMGfvoJqpV90dKCZYgPGmRpjAk5obxezPa3ithW\nWv/Mh4HJIrIAlyyG4arCngYQkUkAqnqFt/9LwC3A8yIyGlfd9hjwuqpuDjF+YwolJMC1AcOYPv8c\nHn3UJZlGjfyLy5gqLpSE8pdwXlBVXxGRhsDNQDNgGa5LcMHdxuFB+2eLSA9cQ/xC4FdcIrsxnHGZ\nOLZ8Obz5ppsb7Jln3IRhJcjNdYt8bdxoC3wZE6jUhKKqL4T7oqo6FhhbzGvdi9j2La4h3pjwu+oq\nOOkkuOIK6NuXY886Czp2hHqHDrWaPBnmz8eWIjamCDZ9vTHg5sWfPx9uuYWmH38MEycessvGjW4A\nfn6+m+S4YCnijRujH64xlZElFGMKJCfDHXew6Jln4K9/ddu++AKyXV+QNWsOnW/SliI2ppAlFGOC\n7DrqKNf7a88eN8q+QweYM4dWrWDfvoP3zc2FVrbwtTGAJRRjipeSAq++6n7u1o20B//OuCdyC5ci\nTnFtKNYwb4xT9k74xsSTLl1g6VL4xz/goYcYcOx7TD5hLlvyGjBjhiUTYwLZHYoxpUlNdevXf/gh\nnHkmuTXru6WIG9koe2MCWUIxJlRnnQVPPknmbCFzwio4+mh47jmbwdgYjyUUY8pj715o3tzNCXbS\nSfC///kdkTG+s4RiTHkcdxzMnQtTpsDmza6t5bLLCte2NyYOWUIxprxEoH9/+OYbuPVWOOywwrXt\nc0NeJsiYmGEJxZiKqlULbr8d7rvPPZ8zB446yt292B2LiSOWUIwJt5QUaNoULr8cTj8dFi70OyJj\nosISijHhduKJsGCB6wG2ejWcfPLB0+UbE6MsoRgTCQkJ8Je/wHffwY03QhtvTbj8fMjJ8Tc2YyLE\nEooxkVS7NtxzT+Fkk1OmwLHHwmuvWfuKiTmWUIyJplat3AJel1zi1hL+8ku/IzImbCyhGBNNnTu7\nKfGfftqtFJmRAaNH+x2VMWFhCcWYaEtMdCtzffcdXH89dOrktufkuBH4xlRRllCM8Uu9evDQQ3D+\n+e75ffdBu3Ywfbq1r5gqyRKKMZXF6adD9erQty/07AnLlvkdkTFlYgnFmMqiRw9YsgQef9y1s3To\nAE884XdUxoTMEooxlUlSEowc6dpXRoxwdy0A27cfuv6wMZWMLwlFREaIyBoRyRGRxSLSpYR9u4uI\nFvE4NpoxGxNVDRu6u5MTTnDP/+//oH17mDHD37iMKUHUE4qI9AMeA+4GOgHzgBkicngph7YDmgU8\nvotknMZUKhdd5EbZ9+rlHt9843dExhzCjzuUUcBEVR2vqitUdSTwMzC8lOM2q+rGgMf+yIdqTCXR\np49rpH/oIbcOS/v28NJLfkdlzEGimlBEJBnIAGYGvTQTOK2UwxeJyM8i8omInBGRAI2pzJKTYdQo\n174yZIgbaQ+wcqVb5MsYn4lGsb+7iDQH1gPdVPXTgO23Apep6jFFHHMMcAawEEgGBgDDgO6B5wjY\nfwgwBKBp06YZU6dOLXe82dnZpKamlvv4qszKXnXK/rsbbqBuVhY/9+nDj/36kdu4cYXOV9XKH07x\nXHYoLP8ZZ5yxWFVPLPMJVDVqD6A5oECXoO23Ad+U4TzvA2+Xtl9GRoZWxKxZsyp0fFVmZa9Cvv1W\n9corVRMTVZOTVYcNU12zptynq3LlD6N4LrtqYfmBRVqOz/hot6H8AuwH0oK2NwE2leE884HW4QrK\nmKqoe3ev1qtNG3j+efj+ezdl/nPPQQXuzI0pr6gmFFXNBRYDPYNe6onr7RWqjriGfGNMgfR0N+nk\nqlVwzTVu29SpcNll8PXXvoZm4oMfvbweBq4UkatFpK2IPIarCnsaQEQmicikgp1F5DoR6SsirUWk\nnYjcA/QFxvgQuzGVRm6uG++4cWPQC4cd5tZhAddYP306HH+863ps0+WbCIp6QlHVV4DrgJuBJUBn\noJeqrvV2Odx7FEgGHgS+AuZ4+/dW1TeiFrQxlczkyTB/PmRlwZFHuudFuvZaWLsWbr4ZPvrIDZS8\n7rqoxmrihy8j5VV1rKqmq2p1Vc3QgN5aqtpdVbsHPL9fVY9W1RRVbaCqXVT1fT/iNqYy2LjRzX6f\nnw/798OePe75IXcqBRo2hDvvdInlP/+BLt7EFDt3wqeHdJQ0ptxsLi9jqpg1a9yUX4GSk932EtWr\nBzfdBBde6J5PmADdukHXrjBzpk2ZbyrMEooxVUyrVofOE5mb67aXydChbmbj1avh7LPh1FPhnXcs\nsZhys4RiTBWTlgbjxkFCglv8MSXFPU8L7oxfmpQUN7PxqlXuBJs3wyOPgEhE4jaxzxKKMVXQgAFw\nyiluSq/Vq93zcqte3U3lsnIlTJnitq1f7xrwp0yBvLywxGxinyUUY6qo5GSoW7ccdybFSUqCZs3c\nzxs3unq1yy+Htm3dYElbj8WUwhKKMeZQGRmwdCm88QbUqQODBsGxx7ouZUEOjNg3ca+a3wEYY8on\nMzPCF0hIgAsucGvcz5jhlidOSXGvvfUWnHUW1KwZ4SBMVWJ3KMaYkom4Rb3+/W/3fOVKl2jS0+G+\n+0jYnV30iH0TdyyhGGPKpk0bmDMHTjiByTcu47OFiXy7dA9HttLiR+ybuGAJxRhTdp07s3HiBwyt\n/gI5pLBHU9iTI27E/uL11jMsTllCMcaUy5o1kFT94I+Q5GRlTf+b3ARj//mP1YPFGUsoxphyKXbE\n/j8vcT3CbrkFWraESy6BhQv9CdJElSUUY0y5FD1iX0i7qpebG2zlSjfb8ccfw7Jl7qDsbPjtN38D\nNxFjCcUYU24ljthv3RoeesiNuu/f320bPx5atIDBg+GLL8IWh42FqRwsoRhjKqTUEfspKW56F4Ae\nPVxymTLFDZ485RR44QWbkDJGWEIxxlRIZmYZBlm2b+/uUjZsgMcegx07YNKkwgkpN20qVwzFrl5p\nosoSijEm+urVc+0ry5fDa6+5bRs2uEb8s86CN98MuetxyKtXmoizhGKM8Y8INGjgfq5RA269FVas\ngD/9yY3Ev/122Lq12MPLvHqliShLKMaYyqFBA7j5ZjfA5a234Pjj3ViW3bvd69u2HdLWUu7VK01E\nWEIxxlQu1arB+efDBx/AunWuGgzgssvcVPqPPgq//gqEcfVKExaWUIwxlVfTpoU/X365u4u5/nrX\n9fiqq0jbuCQ8q1easLCEYoypGi67DObNgy+/dANeXn0VPvyQAQPgtJNyyWiXU/HVK02F+JJQRGSE\niKwRkRwRWSwiXUI8rrOI5InIskjHaIyppDp2dLch69fD8OEAnL39NT75Oo20mwa5kfn79/scZHyK\nekIRkX7AY8DdQCdgHjBDRA4v5bj6wCTgk4gHaYyp/OrWdatJAjdPaUvqZee7Lsg9e7oqsZEjYe9e\nn4OML37coYwCJqrqeFVdoaojgZ+B4aUcNwF4Afgs0gEaY6qYE05wI+43bYLXX4fOneHzzwtH6L/6\nKnz1lY3Ij7CoJhQRSQYygJlBL80ETivhuBFAGvCfyEVnjKnyUlLgwgtdUpk/323btw+GDYMOHQq7\nIn//vb9xxqho36E0AhKB4PkVNuESxiFEpD1wG3CZqlrFqDEmNAnex1tSEnz7LYwdCw0bumn1W7eG\nhx/2N74YJBrFW0ARaQ6sB7qq6pyA7bcBf1bVY4P2rw58AdyrqpO9baOBi1T1+GKuMQQYAtC0adOM\nqVOnljve7OxsUlNTy318VWZlj8+yQ+yXv/rmzTSZNYttJ5/MrlatqLdkCekTJ7LpzDP54cQTqd68\nud8h+qbgvT/jjDMWq+qJZT6BqkbtASQDecDFQdufBGYXsX86oN4xBY/8gG1nlXS9jIwMrYhZs2ZV\n6PiqzMoev+Ku/O+8o3rMMaqg+xMTVXv3Vn3xRdXcXL8ji7qC9x5YpOX4jI9qlZeq5gKLgZ5BL/XE\n9fYKth5oD3QMeDwNfO/9XNQxxhgTuj593PxhX3zBuosugqVLYdSowhmQly+33mIh8qOX18PAlSJy\ntYi0FZHHgOa4RIGITBKRSQCquk9VlwU+gM3AXu95tg/xG2NijQh06sTqYcNg7VrXQ6xaNTfr5Dnn\nuBH7V10FH30U8izI8SjqCUVVXwGuA24GlgCdgV6qutbb5XDvYYwx0ZeQcPBkYOPHQ9++MG2am1q/\nRQu3hos5hC8j5VV1rKqmq2p1Vc1Q1U8DXuuuqt1LOHa0FtMgb4wxYZWQAGefDRMnujEu06ZB167Q\npIl7/dtv4cYbXTWZjXGxubyMMSYkNWq4dVpee81Vg4GrGnvwQTcdTLt2TGh1J5efvNLfOH1kCcUY\nY8pr4ED4+Wc3xqVRIwb9cCsTFndwK32Ba4/JzfU3xiiyhGKMMRXRuLGbpPLTTzm30zqGHPEhG7en\nuNcuvhgaNXKj959/PuaXkrSEYowxYTB5Mry/tAVTfuxauLb9LbfApZe6qrGrroJmzdx6LgVirN2l\nmt8BGGNMVRe4tj0Urm3fc/W5pJ17rkscS5fCu++6+cTAVZVlZMAf/wi9e7tZkmvX9q8QYWAJxRhj\nKqhgbfuCphMoXNs+LQ03zqVjR/cosGuX6zE2bRo895w7Qdeu8Mgj0L59heLp3t39m5lZodOUmVV5\nGWNMBZVrbfujj4apU2HLFvfJf911sGED1K/vXn/jDTdi/5NPqkzDviUUY4ypoLQ0yr+2fVISdOsG\n99/vpnk57DC3fdky13usRw/XsH/RRW48TAjtLrm5sH179PsAWEIxxpgwGDAATjnF1VaFZW37W2+F\nrVth+nT4859dw/7jjxfOMfbSS7BoUWHDjWfyZLcUTFYWhZ0DosTaUIwxJkySk90jpDuTUNSqBeed\n5x6qrnoMXP3a0KGQne0u1qsX9O7Nxt+dxdChqYd2DugZxphKYHcoxhgTJpmZEWwIFymc8iUpyd0G\nTZrkqsveeAMuvJA1d79MUtLBhxV0DogGu0MxxpiqqHFjV682YICbAXnePFqltGJf0JqCpXYOCCO7\nQzHGmKquWjXo2pW0k1p6nQO07J0DwhFGdC5jjDEmGgYMgKeeEvbsgRkzopdMwBKKMcbEnLB3DgiR\nJRRjjIkx0R4hX8DaUIwxxoSFJRRjjDFhYQnFGGNMWFhCMcYYExaWUIwxxoSFJRRjjDFhYQnFGGNM\nWFhCMcYYExaiISzWUlWJyBZgbQVO0Qj4JUzhVDVW9vgVz+WP57JDYfmPUNXGZT04phNKRYnIIlU9\n0e84/GBlj8+yQ3yXP57LDhUvv1V5GWOMCQtLKMYYY8LCEkrJnvE7AB9Z2eNXPJc/nssOFSy/taEY\nY4wJC7tDMcYYExaWUIwxxoSFJRRjjDFhYQnFGBP3REQC/zXlYwkliIi0FpGmfsfhF/vDil/x/N6r\n1ztJA3opxdP/Q7jee+vlBYhIE2AAcD2wBcgDfgZeB6ap6i4fw/NVwS+YxvgviogcBxwH1AV2AfNV\ndY2/Ufkrjt77dkBb3Hu/G/jc3vvyvfeWUAARmYj7MHkX2Ao0BDrifsnWAfer6ke+BRgFIpIAnA80\nBmoC64HZqrrZ18CiQERuBC4DWuPKvRXIB74EXgLm4v62YvKPxd57e+8J03sf9wnFy8Q7gV6q+mnA\ntpbAKcBg4Aign6ou8S3QCBKR2sAE4AzcH9M6QIE9wGzgRVX9RkQk1v6wRKQh8ANwg6o+LSItgZOB\n3wMZQA3gX6qa6VuQEWTvvb33hPG9rxapYKuQ44A1QG7BBu8/70fgRxGZDswD+gExmVCAa4FjcEl1\noYgcC5wIdAbOBn4nIoNUdYufQUbIxcA3qvo0gKr+BPwETBORDsAtwNsi0lFVV/sYZ6TYe2/vffje\ne1WN6weQAnwCfIa77U0oYp+RwBK/Y43g/8EcYFQR2xOBrsB3wAd+xxmhsl+M+0LRNaDMiQGv1wA+\nB0b4Hau99/beV/b3Pu57eanqHuAmXGKZBFwhIi1FpBaAiNQEugHL/IsyckSkGq5sF4pIY29boogk\nqup+ddWAw4DDvG9tseY9XLXHKBFp75V5f8GLqpqD66TR0Kf4Isbee3vvCfN7H/cJBUBVPwcux1Vz\nPYVrkJsqIs8B3+DaU+7zL8LIUdU84AUgDfi7iDQN/sMCVgLpxNjCQ17d8G5gNNAGWCgib4jIeSLS\nSkQyRGQk0A6Y7GeskRDw3jcHboin996zB7gDV+0Tr+99WP/u475RPpjXhbg30BfIwWXx11T1G18D\nixCvl0cC8Bfgbly72uvAK7j65N8B5wJtVfUkv+KMBhHpD1wFnIZrpNzk/TtGVR/zM7ZIEZEk4M/A\ng0Ayhe/9j8Twey8idVV1e8Dzy4EhQCfc38AG4uO9v5LCv/s3gKlU4L23hFICEUlQ1Xy/44gWEamH\n+wXrj+s2vRPYCywA7lHV+f5FF37ebf9+oJ6q/uol1+q48QjHAQ2AOaq6yccwI0ZEUnHtBFuBOrhk\n+mfch8le3JiM+cTYey8iJ+HuTD7B/W4v8u5UC8Yj1Qda4LrPxtx77/Vm26Oqv3jP6+He+wuAk3Bf\npHdTjr97SyhxTETqADs14JfA+1CtAaQCxwO7YunDpIA3mO3vwJnAIuB2Vf3K36iiR0T+APwL16tn\nLnC1qv4sIvVxSbUFUC1G3/u7gRuBTCAJV639IVAPeFRVU/2LLvJE5L/AUlW93nsuuL/5VsA2719R\n1XllPrcllPglIuNw30IWAGtVdUcR+9T3vr3H1DgEEVmI++OZiavebIPr7fNtwD61VXWnTyFGjPcB\nshL4APgfrn3wLtw384646o97VPVL34KMIBE5Hdcu8hAuiZyFG9TXAndXfhOwWGNwtLz33ucAp6rq\nl94Xq3txPVx/wg2NuF1Vs8t1/hj6jDBlICJ/BqYAO3AfrB/hvqV9BaxX1T1elciLwC2qmuVbsGEm\nIgNxdyddVPU3749sJq7cVxYkTxF5DHhcVVf5GnCYiciVuPKf5L3PfwSex/V4ysIl1wbAOaq63q84\nI0lEhgBdgCtwd2Q9cW0I3+P+JnKAq2LwvR+MG8jZRkSOxrWZ7AGm4TonnI/rlNSvPEnFennFrzNx\ny32eAIzFNUS/CLwG3CwiZ+LmN+sVS8nE8yfgPS+ZJHt3XncDp4tIay+ZdANGxtoHiqcf8JbXZR7c\nyPBNwAWqOhg37qomEItdhQuqdZ/HJZLrve7B1XDz9/XB/V18F6Pv/RDgU+/nS3Gj4y9V1UdVdTgu\nwZ6Cq/YqM0socchrjF4D/Kaqq1X1QVVtj2uQmw0MBF4FniDGukyKSHVgH7DduxPJFZFqqjoL938y\nzNt1CC65xhQRqYG7I10csLknMM5rQxFgBbAc12U25qhqvqruA8YBI0QkDRgBvKGqq1R1gqpe7W+U\n4SciKbjP/D+IyHvADbjJb9d7Y1AE93uxAvclo+zXsCqv+OQ1vjZVN1dPMrAvqHG+H/AycILG0Bxm\n3h9NJ+AMVX0osG1IRHrj7tI64eqSe6vqXP+iDT+v/IcBqaq6wnveEtikqnu9fVKBVbjyL/Iv2sgT\nkRG4WcaPAk5W1UUFg/t8Di3svPe6Fa6q7xzc+KM7VPWTgH1ScSPk+6jq4iJPVAKbyytOqeqvwK/e\nz7lwoCpAvD+mOkBOLCUTODBP2xfeI9hMXI+nGcCOWEsmcKD8PwU9/9H7sCn4HbgQ997HdDLxTMC1\nHdQAvgaIxWQCB97r1cBqEXkZN2ixoNqz4L2/GMgrTzIBSygmQNCYm9rAbX7FEi0BdyeiqvtEZAqu\ns8JoXwOLsoC70764ar9HfAwnalR1r4jcgLtj21PqATHC+xK5Mmjzn3ATRpZ7IKdVeZkieaNo98fT\nwE44UC1wIrBaVbf6HU+0eeU/HNhSMNjPxAfvvU8HNms5FxW0hGKMMSYsrJeXMcaYsLCEYowxJiws\noRhjjAkLSyjGGGPCwhKKMcaYsLCEYuKKiPQVkVFFbB8tIpWiy6OITBQR9R6ZETj/zQHnXxfu85v4\nZQnFxJu+wCEJBXiWcs5fFCEbcfGMiMC5n/fO/X4Ezm3imI2UNwZQ1XW4mVcri72q+nkkTuxNSb9e\nRLZE4vwmftkdiokbIjIRN5Nyi4Aqnx+81w6q8ip4LiLHisiHIrJLRH4Ukb94rw8QkW9EJFtEZonI\nUUVcr4OIvC0iv4rIHhGZKyJdKhB/gojsFJFbg7bX92Id6D1vIyJvishmEcnx4n7Nm2XamIixXzAT\nT+4EGuOm6T/P27a3lGNeA8YDD+Kqn54TkdZAd9wyskm4uY9ewq0jAYCInADMwS1WNBi3Rvcw4GMR\nOa2ck++1wS3NHLySYifv34Lt7wK/AcOBX3ArEfbCvkCaCLOEYuKGqq7yqnlyy1Cd9ICqTgIQkUXA\nucBQoFXBkski0gx4TESOUNW1BccBPwJnBszm/CGwDLgF15ZTVid4/wbPlNwJlxhXiEgj3HKu56vq\n2wH7vFSO6xlTJvaNxZiSzSj4wZvyfzPweUEy8Xzj/dsSDixk1A13d5MvItW86iYBPga6ljOWDNzE\nfcHL8p4AfO0tGrUVN0X5vSIy2LubMiYqLKEYU7Jfg57nFrMN3Joa4NZjT8TdiewLevwVqO+tPVFW\nJ1D0Oi6d8Kq7vGnoewKLgHuAlSKyWkSGl+N6xpSJVXkZE36/AfnAk8CkonYo67IA3tTiHYGngrY3\nwS0Q9WTAuVcDV3jHdMAlsbEi8oOqzsCYCLGEYuLNXiAlkhdQ1V0iMgf3Yf5FmNaUOQqoBwSvJjgS\nV9NwyMqa3t3KEm8g5yDgeAKq8IwJN0soJt4sBxp4VUCLcEvdZkXgOqOAT4EPRWQC8DPQCFdtlaiq\nN5bxfAUN8leLyE+4tpyzcN2gAU4UkS9wDfKPAa8A3+Oq3q4E8oD/lrs0xoTAEoqJN88CpwJ3477x\nr8WtUhdWqvqFiJyEW0b5caAusAXXBvJ0OU55ArAN11X5Xlz34bdwa4C/DPRT1cdEZCOud9ko4DAg\nB8gC+pR3nXBjQmUrNhpTyXgDMLsDR+NqrvaLyEe4Jz3DcH7B3blMAP6gqodV9JzGgPXyMqayOgLX\nK+wT73knIFx3GDd5574iTOczBrA7FGMqHRFJx7W3AOzEVVv9AFyiqq+F4fzNcKPnwQ3y/Kqi5zQG\nLKEYY4wJE6vyMsYYExaWUIwxxoSFJRRjjDFhYQnFGGNMWFhCMcYYExaWUIwxxoSFJRRjjDFhYQnF\nGGNMWPw/IBr+zY3fT9AAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x110d0bc18>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a: 0.74 ± 0.04\n",
-      "T1: 31.84 µs ± 3.63 µs\n",
-      "c: 0.18 ± 0.04\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# arrange the data from the run\n",
     "\n",
@@ -232,7 +179,7 @@
     "    sigma_data[ii] = np.sqrt(data[ii]*(1-data[ii]))/np.sqrt(shots)\n",
     "\n",
     "# fit the data to an exponential    \n",
-    "fitT1, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([0,2,0], [1., 500, 1])) \n",
+    "fitT1, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([-1,2,0], [1., 500, 1])) \n",
     "ferr = np.sqrt(np.diag(fcov))\n",
     "\n",
     "plot_coherence(xvals, data, sigma_data, fitT1, exp_fit_fun, punit, 'T$_1$ ', qubit)\n",
@@ -244,44 +191,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The last calibration of $T_1$ was measured to be"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'43 µs'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "str(params['T1']['value']) +' ' + params['T1']['unit']"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Measurement of $T_2^*$\n",
     "\n",
@@ -292,11 +220,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -335,60 +261,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running on backend: ibmqx4\n",
-      "status = RUNNING (20 seconds)\n",
-      "status = RUNNING (40 seconds)\n",
-      "status = RUNNING (60 seconds)\n",
-      "status = RUNNING (80 seconds)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result=Q_program.execute(circuits, backend=backend, shots=shots, wait=20, timeout=600)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEzCAYAAAAfN1WMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsnXd4VFXawH8nISEJJTRhKAoJvXeRplkFBcS+KssSwbIg\n+NndVXZ1beuuu6vYRaxILIvCKsIKKkIEBEWQYEgoQgJICUgNgfSc748zA5MhZZK5bWbO73nmmeTO\nuee8d8p9z3nPW4SUEo1Go9FoakqE3QJoNBqNJjjRCkSj0Wg0tUIrEI1Go9HUCq1ANBqNRlMrtALR\naDQaTa3QCkSj0Wg0tUIrEI1Go9HUCq1AwhwhRJIQ4jG75dBoNMGHViBhihDiViHEBK//Bwoh/mWn\nTBqNJrjQCiR8mQ00BP4BjHM/nrZTII3GH4QQCUKIT4UQvwohpBBitt0yhSt17BZAExhCiPrAcfyf\nDDSRUh51/+2dx6bM/dBoKkQI0Qe4GpgtpdxpoyizgV7AU0AOsKO6E4QQDYG7gWuAjkAksBNYBDwj\npTxokqwhjdC5sIIbIUQjYKzP4anAEOAB4IDX8UIp5cfu824FioBfgCTgc+C3Uso/mS2zJjgRQkwC\n3gF+I6VMtUmGukA+8LKU8i4/z+kEfAG0Bf4LLAeKgQuACagJ2Fgp5femCB3C6BVIkCOlPAa8531M\nCHEvUAC8IKUsqeS8t9xtk9z/rwXWmipsmCCEiATqSilP2S1LCNICEMARfxoLIeKAhUBr4Aop5f+8\nXn5dCPEqsBT4TAjRU69EaoiUUj9C6AFEoZTH9zaNPwllGrsE+CuwCzVj/B64wN3mImAVcBLYDzxS\nQT91gT8DGe7rOYa6EfT1adcA+Ju7/0NAIbAdtZ8TV0G/McBjwFbglLvfdODfXm0ec19DuwrO3wmk\nVnC9I4BHUOaUYmBSLa7F6vfOM97FqNXqDvf7tw2Y6NPW8574Pmb7+75W871pBryCWhF7VsavAE29\n2syuRIakKvq9093mn1W0meZu45es+nHmoVcgoUd31A1kg81yPI2yM78ARAP3A18IISYCbwGvA+8D\nNwBPCCGypZTvAQghooAlKDNcCvAyEA/8AfhWCHGhlHKde5zWwG3AfOADoAR1k/0T0Be4zEeuV4Bb\ngDnAc24ZO6JuooHwDEp5vwHkom6kNb0WD1a9dx7+DsQCs1AKZCowWwixXUr5rbvNf4GWwGR3+83u\n4579h1q/r0KIeGA10AF4G/gR9dlNBS4WQpwvpTzhli/N3f8nbpnwkqUifut+fqOKNrOB54HrgD9W\nJ6/GC7s1mH4Y+wBuRs2mJts0/iT3+D8C0V7Hr3QfLwEGeh2PRs2k13gdu9fd9jKfvhsCuym/AogG\noiqQ40l3H+f7HD8CfF7NNTxGzVcgW6l4xVOTa7H6vfOMt8FnvNYoRfJhJZ9tUgXXWe37WsX7/ZS7\n32k+x+9wH3/S61g797HH/Oz7MJDrR7t0d7/17fjdBOtDu/GGHv3cz3avQGZKKYu8/l/pfv5OSvmD\n56C7zVrUbNXDBGALsF4I0czzQN0wvwKGCSFiPedLKYsBhBB1hBCN3W2Xuvsa5CPXcaC7EKKHMZd5\nmpmy4j0Pv6/Fpy/T3zsvXvUeT0q5F2XG6oj/BPK+XgP8ilpZeTMLZZa8phZ9emjolq06PG0aBDBW\n2KFNWKFHX9RMNd1mObK8/5FSHhVCAGRX0PYo0NTr/64ok8qvVfTfDGUnRwgxDbgdZb7znRQ19vn/\nHpRpJ10IkYXyyFkILJRSBuLGvK2S4zW6FjeWvXcVjefmMMpryV8CeV8TgHXSx+FDSlkihNjKmUlR\nbchFKZHqaIhyYz8EajICPAsko75T84E7pJQFAcgScmgFEkIIISKA3sBmB3zRS2t43BuBUoD3VdHm\nVwAhxH2oH/qXwIvAPtQmbGuUbbucQpFSLhBCtAPGoPZKRgC3AiuFECPcM/GqfNsr+81U5nHl97V4\nYcl750e/wo/xAL/fVzvYBFwohOggpdxeUQO3p1ZnYJdnNYtyQvgN0BP1ffoM+Bfgl+twuKAVSGjR\nEaiPsqGXw+0//zLKw+cclO38JSnlS5ZK6B8/o2Rc5sfsNRm1LzHau60QYlRlJ0gpj6Bcn98Tamr/\nNGrT/SrgY864iDZx9+3pMwa1kVzhjciAazECM8erMmjMj/e1MrKAzkKIOt6rEPcqoBMVr5D8ZT5w\nIcrR4qFK2tyEMvF5u8PfBvzJbc7DnS/uIyHEvVJKfxR5WKD3QEKLqvY/6qCidi9FeeXcADwshLjB\nItlqwhzARSWzaCFEC69/S1E3NuH1eh0quFkIISLdgZenkWoH1fN+NXE/e8xRI3y6uJea/2Zqci1G\nYOZ4ee7nJt4Ha/C+VsanKKV3m8/xP7iPf1IraRVvoj7PeyuaVAgh+qHS+exHeZJ5gnPPRXl8efgR\nZeZqF4AsIYdegYQWfd3PZ61ApJQnUXEKHtKEEJ8Dw4CPLJCtJrwAjAT+LYS4GFiGsmWfh1pBFaDM\nCwDzUDeAxUKI/6J+5ONRsRi+NAD2CyE+Q93cDqLs71NRewkL3e2WojainxBCNEXtPQxDRS4fMvFa\njMDM8X5A7RP8RQjRGBWLko3yQPPnfa2MfwHXA6+4b+gbUN/lW9191zrJp5TylBDiSpRr8/+EEPOB\nVNQ+4fmoFexR4EoppSdrg2cj/ZhXV8d8XtOgFUio0Rc1G99YXUN3vMAw4J9mC1VTpJTFQojLUQFe\nycDj7pf2obyO3vVq/m/U6uNW1M0zB5iLSrmR6dP1KZS//yWo1UV91MzzM+AfUsp97vFLhRBXofZU\n7kTZwL9E2fa/pQbU8FoCxszxpJS7hRC3AA8CM1FxL++iYkOqfV+r6Pe4EGKoW9YrUa7oB4DXgEel\nigGpNVLKrUKI3qhcWNei9mnquV/OAIZJldHBg2e8eNT3CaCRz2sadC6ssEUIMQtl8hpq4wanRmML\nbjPnx6jkkPdLKWf4vL4b+KOUcq77/0tRq93Geg/kDHoPJAwRQswABqM2nrXy0IQd7s36G1FJRJ8V\nQkz1afImMF0I0UoIcQ4quHS2Vh7l0SuQMEMI4TE1XCylrCpWQKMJW9wrlBmciQOZB/yflDLfVsEc\nhlYgYYQQ4kVUbqLfaOWh0WgCRSuQMEEI0RYV01CI8kDxsFJKOdoWoTQaTVCjFYhGo9FoaoXeRNdo\nNBpNrQjpOJBmzZrJdu3a1fr8kydPUq9eveobOpxQuQ7Q1+JEQuU6QF+Lh/Xr1x+SUp5TXbuQViDt\n2rVj3Trf2jn+k5qaSlJSknEC2USoXAfoa3EioXIdoK/FgxBilz/ttAlLo9FoNLVCKxCNRqPR1Aqt\nQDQajUZTK7QC0Wg0Gk2t0ApEo9FoNLVCKxCNRqPR1AqtQIKQnBxYs0Y9azQajV1oBRJkpKRAYiKM\nGqWeU1Lslkij0YQrWoEEETk5MGUK5OdDbq56njJFr0Q0Go09aAUSRGRnQ1RU+WPR0eq4RqPRWI1W\nIEFEQgIUF5c/VlSkjms0Go3VaAUSRLhcMGsWxMZCfLx6njVLHddoNBqrCelkiqFIcjKMHKnMVgkJ\nWnloNBr70Aok2Pj5Z1xNmuAa3NRuSTQaTZijTVjBxt13w6BB8NVXsHOn3dJoNJowRiuQYGLvXvji\nCxgxAq66CqZPt1sijUYTxmgFEkzMmQNlZfDAA3D//fCf/8DatXZLpdFowhStQIIFKeHtt+HCC6FD\nB/jTn6B5c6VMpLRbuqBAp4DRaIxFK5BgYeNG2L4dbrlF/d+gATzxBKxcCQsW2CtbEJCSAq1bw/Dh\nOgWMRmMUWoEEC336wLZt8Nvfnjl2661w0UVQUGCfXEGAJwVMWRmUluoUMBqNUWg33mCiY8fy/9ep\nA8uXgxD2yBMkeFLA5OefOeZJAaPjaDSa2qNXIMHAe+/BtdfC8eNnvyYElJSo/ZGKXtfoFDAajUlo\nBRIMzJoFmZnQsGHFr2/apMxZ//yntXIFCToFjEZjDlqBOJ1t22DVKrj55spNVX36wO9/D889R876\nvdrTqAKS+2eS9dZyFi8sIStLpYTRaDSBoRWI03nnHYiMhJtuqrrdU0+RUjyOtgPO0Z5GFfHKK7hu\nvZzBHQ/hum0s/PST3RJpNEGPViBOpqREBQ+OHg0tW1bZNKduW6aIWRQRrT2NfCkrg//+F8aMgRMn\nlEv08OGQmmq3ZBpNUKMViJMpLIQ//AHuvLPaptnZEBVX3qlOF5tys3q10qTXXac82VavVkEhl10G\n8+bZLZ1GE7RoBeJk6tWDxx6DSy+ttqnyNCr/cWpPIzfz50PdunD55er/c89V+0oDB8INN8B77zFk\nCPTtq1dsGk1N0ArEqRw+DJ9+erb/aSWc8TSSxDcoIzZGak8jD6tXKyXs7cXWpInKaPyHP5Dy6yi+\n/x7S0/XekUZTE7QCcSrvvQfXXANbtvh9SnIyZGUWsvjkhWRN+af2NPKwerWKk/ElNpacx2cx5S/N\ndJS6RlMLtAJxIp7EiQMGQM+eNTrV1S6GwV2O4spabZJwQUhkJDRrVuFLnih1b/TekUbjH1qBOJDf\n905nzU9x5Fx3R+066N1beRqFO1JCUpKy7VWCjlIPjJwcyMhoqFdsYYpWIA4jJQXmpXdhFEtIfHxi\n7ezxvXvD7t1w9Kjh8gUVGzfCN99AROVf83JR6iKX2MhCvXfkjZTqDXr9dVi6FLKylHs5ZzIc33VX\nH713FKZoBeIgVNZYSRHR5BJPfoGonT2+Vy/1nJ5uuIxBxfz5SnlcfXWVzZKT1X1x8YhnyWo2iOQJ\nur7KaX74AW6/XW0MjRwJ7dvDpEmnv6tlZVBWFqH3jsIUWxSIEGKaECJbCFEghFgvhBheTfvxQog0\nIcQpIUSOEOI9IUTIzRGVPb58upJa2eMHDYL334euXY0TLhiZP1+luz/nnGqbulww+MpzcB3YCL/8\nYoFwQcLx46yJvZjLO28nZ/63am/u5pv13pEGsEGBCCFuBF4A/g70BVYDi4UQ51XSfiiQArwLdAeu\nBroB71sisIUYZo9v0gTGj/frxhmyZGbC5s0qeNBfxo2Dn39WcSIaAFJyRjKs8Gu+2N6exAlDSKlz\nM1xyifu7Wn6yo/eOwg87ViD3AbOllG9IKTdLKe8E9gNTK2k/GNgjpXxOSpktpfwOeAkYZJG8luFy\nwazkVcRGFhLfUAaWNXbzZvjkE8NlDBrq1FEJKK+5xv9zmjVT5YJ1fRUAcrLzT5upfF2cPXtHERFQ\njzxiRb7eOwpDLFUgQohooD/wpc9LXwJDKjntW6ClEOIKoWgGjAM+N09S+0gueYesxgNYvEQEljX2\njTdUht7SUkPlCxo6dVLmllatanbe//4Hjz9ujkxBRvZrXxCVn1vumLeZKjkZ9u6Ft69/gyyZQPIF\nP9sgpcZOrK5I2AyIBA74HD8AjKjoBCnlGiHE71Amq1iUzF8BEytqL4SYDEwGaNGiBakBJMzLy8sL\n6Pza0Pe776jbJprCwlS2bKlRHGE5XNHRdMnP5/v33yevSRPLr8Ms/PlMoo4coe6RI+S1b1/j1UTC\nBx9w7ty5rLrgAsrq1g1A0uqx4/tVE85Z9hbFXFbuWEFBKfv3f09qatHpY42uPId9SX9ly+7dSqME\nMZZ8JlJassq16FqkZQ+gFSCB4T7HHwW2VHJON2Av8EegF3AZ8BMwp7rx+vfvLwNh+fLlAZ1fY8rK\npIyPl3LatMD7+vFHKUHKuXOtvw4T8etann5aXfvu3TUf4LPP1LkrVtT83Bri6M/l1Ckp4+LknEtm\ny4gIKSMjpYyNlXLOnLObOvo6aoip11JWJuWiRVIOHCh/1ytd9ulTJvdvPGDacIFcC7BO+nFPt3oP\n5BBQCvhaSptz9qrEw3RgrZTy31LKn6SUXwDTgGQhRGjtdu7fr8rSGuE91bWrisAOx7oX8+erRIm1\n2Qy/4AL1vGaNsTIFG6mpcOoUyQ+0YO9eWLmSqk2qmzbB3XeXLzwf5pxO0LlfwqJFcP75MHYsKdnD\n+Di9K9s25pPYpyEpc4LXbdxSBSKlLALWAyN9XhqJ8saqiDiU0vHG839o7XYePQr9+p2J4wiEmBjo\n0iX8ItJ37VKxCzXxvvLmnHPURvrqME8Fs2gRxMVBUpJycR5czQb5L7/Aiy/CihWWiehkUlJwJ+iU\nJLYpJOWKuXD4MDkzPmDKyWcpkZGcknHkyximTJZBGz9j9R4IwAwgRQixFrVBfjvKtPUagBBiDoCU\n0lOCbyHwhhBiKvAF0BJ4HvhRSrnbYtnNpXt3WL/euP4+/hhatAivVch//6uea6tAAIYOVdPtcOaW\nW1Q8UUyMf+2TklTbJUtUnZUwRgVZqjpmIMgnhilR7zDyG0n2niiiosov1KJlAdnZcUHpwWa5ApFS\nzhVCNAUeRimDTcAYKeUud5PzfNrPFkI0AP4PeBY4DiwH/mSd1EFKOAYSLlyoUrl06FD7Pt56S5n/\nwpn+/dXDX2JjlRJZvBiee840sYKB7GyIiiglnzPfoei4OmTvqSzWS5DQqhAw12nDDGyJRJdSviql\nbCelrCul7C+lXOH1WpKUMsmn/UtSyu5SyjgpZUsp5Xgp5R7LBTeba65RaSOM4uBBePxx6oVTePDC\nhfCf/wTWR7grj6VLVa2UmjJqFGzdGvbh6AkJUFxY3uruCbIsl3stHmKjS5nFZFzr/2eTtIGhc2E5\nidWrTyeqM4SSEnjsMRpt2GBcn06nXj219xMo48fDww8H3k8w8vjj8NBDNT9v9Gho3jzszX8uF8xq\n9QSxEQVKSfgEBJ/OvbbY7Zjw32vPVMsMMrQCcQqHDqkVQ7duxvXZsiU0a0b9HTuM69PJ3HFHxYWj\nasPBg/B5SMaqVs3hw2oiM3Zszc/t2FF5El5yifFyBRP795O8+ymyHnrjjJLw8V477ZjQOlJZHkyO\nOTILrUCcwubN6tnIfQshoFcv6oWDAikqYs+rC3h8er4xHi2DBysPtrw8AzoLIpYsUbu/tVEgQqjc\nJiqSxnjZgoUvVaIN1/XDq/deA5Ut4okngjIfvlYgTsGjQIxcgQD07q32QEI8pUnKMwfoxDb+cegP\nxtSmGDJE3Uh/+MEQ+YKGRYuU515NNtC9SU9Xxv5ly4yVK5jYvx/atfPfHT8yUr3vzz5rqlhmoBWI\nU2jVSrmeGp0JtndvNTMM4RTlOTkw5fGW5BNHYVm0MbUpPAGF4RQPIqVyI7/88iqLcFVJQoK6gS5e\nbKxswcRDD8H27TV7DydOVCvetDTz5DIBrUCcwtixMG9e7X+4lfG737Hyf/9TM6IQJTsbokR554OA\na1M0bqySUdY0GWMwI4RaCQcyE65fH4YPV6awcMRjuqupJ9+4cepL++67xstkIlqBOIVTp8zpNzo6\n5N1SExKguLT8NRpSm+K991RK+HAiMhIaNQqsj9GjISMjpFe9lfLUU2r16hvsUR1Nm8IVV6hCcDU9\n10a0AnECublq5vbii6Z03zYlBf74R1P6dgIuF8x6O4qICHX/C6iOii8FBeGT32n0aJg505h+IDxX\nIR7PPd9yjf5w663KeePwYWNlMhGtQJzAli1q6XtehUUZAyZu1y6YO9eUvp2CpzZFtUn/akJ2tor2\nCvH3DoAdO9QNv6io+rbV0bUr3HuvSs0TThw5ohJgjRpVu/NHj4YFC8DlIidH5fN0eo4srUCcgFke\nWG7y2rdX5oQjR0zp33YyM6FHD1w7vvXPbdJf2rZVy5lwyMz7P3ckdG3cd30RAmbMUJ5s4cTSpcpz\nL8BcYCnPHqR1a8nw4RjjUWgiWoE4gcxMtVeRmGhK93nt26s/0tNN6d920tOVzb1+fWP7jYhQ9uxw\n8MRatEhF8Hu+K4EiJfz0E1f1+0WlNHf4TNoQlixRzhcDB9a6i5zvdjLlgfqUlYmzygg7Ea1AnEBm\npirBWsec3JYnPYkFQzW1e0aGutl37mx830OGqP6PHze+b4dw8fl5rPwqn5ykccZ1euIEKX2eZUla\nC9LTnT+TNoSLL4bp0wP6HWfLdkRFlI/ZCtij0ETsSOeu8WXcOFM3aos8syKjXYSdQkaGyr7rb+rx\nmjB4sJpNr10LI33L2AQ/KSmwYn0co8QXyHfqMmuIMftHOacaMkXMoqgsGrxm0iNHGmhidBoTJgTc\nRUICFEfGQNmZY4Z4FJqEViBO4Pe/N7d/IdQNMFTJyDBvw3bQIHj66cDSwzsUT92K0rIIThEHhcbd\n5LOzlSNSfuGZY56ZdEgqkE2blCtuy5YBdeNywaznTjHl/6LU7zYm1jiPQhPQCsRujh1Tifvatw/5\neA1TkFKtEgYNMqf/hg3hwQfN6dtmTt/kvYsbGXSTT0iAYqLLHXPyTDpg7rpLud8aYCZOviOekZ9N\nJHvdYRLSP8PVyrmWA+dKFi4sWaJs95mZ5o6zbJnyKtqyxdxxrEYIeOcdY+uo+HL0KHd2+Yp+fcsc\nu5lZGxISoLiofNJDo27yLhfMel0QQz71xEljY3OcxokTsGpV7d13K8D11lMM3vy2o5UHaAViP5mZ\nam+iUydzx2naFHbvDr2N9KIi0zO/pjyYzltbh7LpJxlSm8EuF8y6ZzOxnCI6otjwm3zyTYLsr3bw\n1ZcGxuY4keXLVfS4gQqENm1UbRWHoxWI3WRmKvOV2fUAunRR3iGhpkCefFJljzWyEJcXOTkwZc4w\n8omjuCzS8W6VNSW55VKySCT10+Om3ORdI3oweES90Fx5eFiyRBUyGzrU2H5ffhnefNPYPg1GKxC7\n2bzZtADCctStqyKEf/rJ/LGsJCMDmjQxzQU6Oxui6opyx5zsVllj0tNxNS1h8Nim5tzkjx9XFQ6/\n+86Ezh3CkiXKhTc6uvq2NWH+fLUkdDBagdhJcTFs22ZsEamq6NUr9FYgZnpg4d4nKC6vQEJqMzg9\nHXr2VHtJZhAVpYolhXJerG++UZ56RjNwoPq9FhZW39YmtBeWnUgJH39sXPRvdYwdq3I7lZSYNmO3\nlIICVXfhxhtNG8LlUpPAWycWEydPUhQbz6xZInRMMg8/bK73X1yccoEOtZWvN0bX8PEwcKCaZP70\nU0DR7WYSAneRICY6Gq6+2rrxxo1Tj1Bh61aVe8jkpH3JyfDR879SeqqAt5c2UHWsQwUjcl9VR69e\nsGGD+eNYzJAhcGH2u9zzZFNct5nwPnqUxg8/OFaBaBOWnaxfrzw4rKSkRMWehALx8ar62/nnmz7U\nwvWt+HxzYmgpj+xsWLHCmAy8VdGrl8r2G0L15VNS4PvvJTNzriZx6qXmeOa1bQutW8Ovv5rQuTFo\nBWInM2bApEnWjtm+Pdx3n7VjmkW7dvCPf1i3IfHmm6FVqvWDD+Cii8y3sffqpUxZIeJ54IngLysT\n5BJPfkm0OZ55QsCuXfDoowZ3bBxagdiJVR5YXiw5Noj//EeGhhvq9u3Wzmqffhpmz7ZuPLNJT1fK\nt0EDc8e5/HIVbNezp7njWIQngt8b0zzzHJ6dQisQuygttVyBpKTAVbnvMSX/eRITZfAHxI0ZAxMn\nWjdely5nareEAh4PLLOpUyekEnkqz7zyx0zzzNu8WdWYd2hJgdD5VIONXbuUF5FFLryeZXcR0WrZ\nnS+COyCuoEDZ1a2sete1q3K7Li2tvq3TKSxUTgg9elgz3jPPwNSp1oxlMi4XzJpZRgwFxIoCc9O0\nNG2q0qQ4tKiZViB2YXIVQl8sXXZbwZYtlnhglaNLF3Xj3bXLujHNYssWpQitMitlZcGHH5qedsYq\nkidGkL0/hq+/jTE3TUvz5qrU9Q8/mDRAYGgFYhe/+Y1Ksd6njyXDWbrstoKMDPVs9QoE4OefrRvT\nLDp3VrNaq2qc9OqlotJ/+cWa8SzA5cLYEsqVMXCgViAaH+Li1BcjLs6S4TwBcRERal8u6LOjZmQo\n27rZSSi9GTAAjh4NuOa1I4iJUeV6mza1ZrxevdRzqAQUTp8O115rzVgDB6oV3OHD1oxXA7QCsYtX\nX4WvvrJ0yORk2LsXVn56mKzFW4M7O+q4cfD228bnH6qK6Gho1Mi68czk3Xfhiy+sG8+z1xIqCuSb\nb+DQIWvGGj5cebI5sKyyLQpECDFNCJEthCgQQqwXQgyvpn20EOIJ9zmFQojdQoi7rJLXcKRUM5gF\nCywf2uWCwTNvwnVPkEek9+plT37wt9+Gv/zF+nGN5pFHrM1L37AhJCWZn3XaCsrKlCK0yPzMkCGw\naJEqLO8wLFcgQogbgReAvwN9gdXAYiHEeVWc9iEwCpgMdAauB4J3KrNvH+TmWpdE0ZcOHVQMRbBu\naBYUwCefqEqOVrN2Lbz2WvC+d6AyEfzyi/VxGcuXw/33WzumGezYASdPWqdAPHiXjnQIdqxA7gNm\nSynfkFJullLeCewHKvTxE0JcCowAxkgpv5JS7pRSfi+lTLVOZIOx2APrLDp0UAF4dtyAjWDzZmV/\nTk21fuwuXeDIEevMF2awaZN6DpHAPstJS1PPViqQBx5Qv1uHYakCEUJEA/2BL31e+hIYUslpVwM/\nAPcJIfYIIX4WQrwohKhvoqjm4ilfa6cCAbUKCUbs8MDy4Fk1BnNAYXq6erZagaxapfI7/fijteMa\nTcOGqvqglb/f885Tlou9e60b0w+szsbbDIgEDvgcP4BaZVREIjAMKASuAxoBLwGtgN/6NhZCTEaZ\numjRogWpAcxS8/LyAjq/MvY9mcnlkY3YkJlpyY3I9zpiDx9mELB54UIO+Pr2Opy8vDx2LV7MuZGR\nrNy3D2lxorm6R48yGNi6YAH7y8oC6sus71d1dPj6a1z16rFq+3ZljgkQf68j9pdfGLR7N1s++oic\n3NyAxzUDv66lbl148EFLi2Q1jIykH7DpnXc4NGyYX+dY8v2SUlr2QN30JTDc5/ijwJZKzvkSyAfi\nvY5d6u6nRVXj9e/fXwbC8uXLAzq/MgZfUCaH9jwu9+83pfuzOOs6ioqkTEmRcudOawQwkOXLl0t5\n5ZVSdutmjwClpVK2aCHlM88E3JVZ369qKSuT8sABw7rz+zpKSqSMjZXy3nsNG9to/LqWU6dMl6PC\nMevUkfI4f2SsAAAgAElEQVTPf/b7lEC+X8A66cc93eo9kENAKeAbfdCcs1clHvYDe6WU3j5snml7\nVRvvjiQlBb5fK/gusyGJidY6wpwmKgomTFDmhGDE5CqEVRIRAfv3B/dmsBAqwtlqIiOVO28wu/L+\n+ivUr299rfLYWPXeOSyg0FIFIqUsAtYDvuGvI1HeWBXxLdDKZ8/DEz0WVDklVD4qSVmZyiKRn499\n+ag2b4bPP7dhYAP4/HNVJtUuzCr/agX796sSAp6NYKvxlFUOVi+2jRuVG68dKRzuvdce1/UqsMML\nawYwSQhxmxCiqxDiBZRp6zUAIcQcIcQcr/YfAIeBd4QQ3YUQQ1FuwPOklEHlRpSdDVGR5e3mtuWj\nevllGD8+OH/InTopbyi7+OwzlcPi1Cn7ZKgtGzaoIMITJ+wZf/RoVYI4yPbeTrNxo3ru3dv6sW+6\nSSsQKeVc4B7gYSANtUE+RkrpWU2ch5dpSkqZh9pgj0d5Y30EfAPcYqHYhpCQAMU+xd9sy0fVoYOK\nbD1yxIbBa0+DzZuV8rPTJ76wUG2gbt1qnwy1xeOBZVUWXl+uu059flZmEDCStDRo0waaNbN+bClV\nNuidO60fuxJsiUSXUr4qpWwnpawrpewvpVzh9VqSlDLJp/1WKeWlUso4KWVrKeUdUkqbplC1x+WC\nWTcsJZZT1IksszcflceVN8gSAzZbtUpVVKxjtQOhFx5X3i1b7JOhtqSnqxtg48b2yVBSonKKBSNp\nadYHEHooLVVjv/CCPeNXgM6FZTHJTReTFduDFSuEuWmgqyNIY0Hq7dypTFi+uemtpEMHtZkejLEg\nVhWRqorOneHuu+2VobbcfjvcfLM9Y9epA337Omoj3cZpXJhSWIirRzNcQ2zeiE1IUJvBwahA/PSD\nN42YGPX+BdsKREql+Pr2tVeOzp2D1xPrjjvsHX/gQHj9dbWKs3MV7sZ+CcKNmTOdsXEdE6Migzt2\ntFsS/zl1ipj9++1z4fXmssuCz44vhNpEt/v716sXLF2qNtLtXEnWlF271HvXtq19nngDByoTVmbm\nmRT5NqJNWHbgFDfQIUPgnHPslsJvbhy8i+/kIHJa9bNbFHjlFXjuObulqB12f/969VLKI9icEJ55\nRjkf2KmABw5Uzw4xY2kFYiUHD8LFF6uspE5g/XqYMcNuKfwiJQXmberK8IhvSbzrcnsCMIOdZ56B\nMWOcsQKB4DNjpaUp990IG2+bHTqoTNRXXmmfDF5oBWIlP/+slEdBgd2SKDzptY8ds1uSKlEBmCp+\nq7Qsgvx8YV8ApofMTOXNtGiRjULUkJUrlRnG7hVI587w1FP2eTPVhrIyFQNit8wREXD11Y6xHGgF\nYiVZWeq5fXt75fAQJJ5Y2dlnm8ptC8D04HKpzKjBtJHuBA8sUB/mn/9sXzbq2rBzpwq+tFuBgLqP\nPPecIyaiWoFYyY4davbnlBxUQaJAEhLODly2LQDTQ5MmKp9UsCiQEyeUxnWCAgEVwGpHPZfaYkcN\nkMpIS1OxUJ6oeBvxW4G4y8qOE0LMFkJsEULkCiGKhBD7hRCpQojHhRBBNKWwgawsZfZwSllPT4lM\nhysQlwtmvVJCLKeIFfn2BmB607Vr8MSCeGqo2BWB7svbb8NvfgOHD9stiX8MHQpz5zrj/XPQRnq1\nCkQIESeEeBTYC7yHKgi1FngD+BfwCSrd+h1AuhDiG3e+Ko0vzZrBhRfaLcUZ4uKgdWvHKxCA5KFZ\nZJHIDecssTcA05suXZQCsXtT2l9GjLAnh1NFeDbSPalVnE6LFnDDDSorrt20aaPkWbvWbkn8igPZ\nAeQAfwU+klJWOmVwK44JwBdCiPullLOMETNEcKLH0w8/OGZDrkq2bsXFAe56dL/9Kw8Po0apzZji\nYufHhFxwAXz1ld1SnMHbEyspyVZR/GL2bJVAs3NnuyVRZvCBA4NjBQJMlVL2lVLOrEp5AEgpv5VS\nTgXaoxIlapxOy5aOiGitltxcaNyYU23a2C3JGa6+Gl580fnKA1QeJSfRooWauASDK++RIyp9yYIF\ndktyhv791Z6qnUlF8UOBSCk/rWmnUsoDUsrvaydSiLJli4r6XrbMbknK88MPMG2afem9/eX3v4fD\nhylp2NBuScpTXKyUm5ORUpk9HnnEbknOIIRahQSDAvFsVjthA93N2KX3cNmgY7ab1LQXllX8/LPa\na6hXz25JyrN7t0qvYkBtbNOxO37BFymVJ9ajj9otSdXk5KiH00yV//gHvPGG3VJUj8cDyyn7R8CR\nskYczIuzNxYKAxWIEKK/EOJto/oLOTwxIB7PJ6cQJK68jBmjXK+chBDq83S6K69no9opLrweBg50\n1E25UjZuVKbeFi3slgRwl8X+HrZsLCDxvGJbszIYuQJpB0w0sL/QIitL1VK2oxBNVXiCGp2sQPLy\nYPFiZxa/8nhiOZlNm9Sz0xRIfr6qjuiAeIYqsbMGiA/eWRkKZAz5xVG2ZmXQJiyryMpSN2unmWHq\n11cBFU5WIJ6iV5062StHRXTpotKDOLm8bXq6+oydNnkRgr2TpvPwqLW2m2KqZMUKZeZ1ABVmZYiS\ntmVlqNb9RgjhMPeNIKVfP/VwIh07qvK2TsWTtbVTJ+cFnnmqE27dan+djcoYMeKMnA4i5eMYJpNF\n5IFSZiQqC6Uj4nt8adhQPRxAhVkZCiUJCfZMTP3x3yxB1SKvLoVsV+CagCUKVR5/3G4JKmf5coiM\ntFuKytm2TT136OA8BXL++fD0087boPYi6Y3fA5D6J5sF8cJjiikgBiSQr/4fOdIBGQa8WbZM/T4e\nesgRDjAul1K0kyZBpCilTmkhsyasxeVKskUefxRIOnBASlmlD6AQ4jq0AqmYsjL1bGca6KpwsvIA\naNQILr3UdpfFCjnvPHjwQbulqJyTJ2mQe4w9shU5OcIxN2ePKcY7jMGTINMpMgKwcKGqAPjYY3ZL\ncprkZKVos3cIEsZdhKtXMpBkiyz+3NHWAwP87M9hBn6H8O23avaycqXdklRMWpqqL+DUAj933QVf\nfGG3FJWzb59jU3KkPLKNrzc0JvOnUhITcUwdFUcmyKyItDQVr+KwSZbLBYOHRuD65Qf1+7AJfxTI\ni4A/EUifA077+J1BVpZKveyoqZUXpaVqppWZabckwcmUKTB+vN1SnEVODkx5uQf5xFFUVod8t5nI\nCRvWHlNMRISkTmSZcxJkeiOlozywnIg/kegZUso5frTLl1LuMkasECMry1lp3H1xsivvwYPqrvLR\nR3ZLUjldu6p9GoelC8nOhijKT/Ntr6PiRXIyDBok6NEzwjkJMr3ZvVsVW3NyrMqqVco92yZXcoca\n5UOMrCw491zn5kxq1Ei5eDpRgWzbBgcOQIMGdktSOV26KPvLzp12S1KOhAQoLin/E3eamWj1atjw\npw9xzXRgNP+uXep75+QVSHy8ivP58UdbhvcnnXuNN8aFEC2FEBfUTqQQJCvLeRHovnTo4FwFAs7I\ngloZXbqoZ4cFFLrOKWVW5DSiKSIyEmeaiUBpkRkzzjibOIULL1QrkPPPt1uSyunaFWJiYMMGW4b3\nZwXyihBioxDidiFEk6oaCiGGCyFeB7YDvQyRMBT47W9hwgS7paiagQOhcWO7pTibbduUu45TzX9w\nRoE4LaVJWRnJ745g1+JMVq7EmWYiUJvUeXmOW8EBynPSqd6ToDJp9+xp2wrEHzfeDsADwBPAS0KI\nzcBG4FegEGgMJKI8teKBFcBIKeVqUyQORu69124JqufFF+2WoGK2bVOrI4d5wZSjSRNVrc5TKc4p\nREXB+PG4AKctOsrhXRvESSv1K65Q3ol/+IPdklRNv37q+yel5Zku/NlEPyWlfAJojSoWtR5VlfAW\n4F7gCiASeAHoLqX8jVYeXpw6Bb/+GjxV65zGkCGO9HA6ixtucNbmAqgcU98HQVWFHj3Ujc9Jqd0P\nHyZn0Q/86dFYR3itVcnIkTB2LJw8afnQfq/NpJTFwNeoAlPdpJSNpJQxUsrWUspLpJSPSykdtoZ3\nAEuXqpTf69bZLUnVbN+uUnE4Ld7igQfg4YftlqJaxg3K5h9d3nXWROFf/4Lrr7dbiuqpVw+6d3dU\nOp2Uf+8nkSxeOHCjo+JnKuS665SA9etbPrQ/m+iRQojHhBDHgANArhBivhCikfnihQBOTePuS5Mm\nyufdSbEgRUVQWGi3FH7R5ddvSNr6Gjk/7rNblDNkZKgbczDw00/w7LN2SwG442dmdHbHz0Q5Kn6m\nUqRU+0gW488K5HZUPfQfgWeABcBVwHMmyhU6ZGWpRGxNqvQ/sJ8mTdQmupM8sZYvh7g4+O47uyWp\nkpQU+NvOZEaxmMQhLmfMVktL1aZ+jx52S+IfDspS7fT4mQpJSlJmVIvxR4H8AXhDSnmxlPJBKeX1\nwB3ABCFErQIbhBDThBDZQogCIcR6IcRwP88bJoQoEUJsqs24tuBx4XXQD6RSnObKu22bcu102t6C\nF56kgKUyklwakV8U6YzZ6o4davUWLCuQ9HS46CLbvIm8SUiAYlnev8hp8TNnkZBgiyuvPwokEfjY\n59hc1MZ5jX0rhRA3ojbc/w70BVYDi4UQ51VzXmNgDmofJngIhhgQD05UIA0bqj0kh1JhfQYnzFY9\nRaSCRYHUr6/qbqxfb7ckKs3K29FERODs+Blv+vZVs5b9+y0d1h8FUh/I9Tl2wv1cm/Dg+4DZUso3\npJSbpZR3AvuBqdWc9xbwLrCmFmPax/TpcNttdkvhH0lJcMEFztkI3rZN1QBx8OrNsUkBR46Eb74J\nHhNW27Yq6tsJnlhlZe40KyrEwrHxM954ag1ZvILz1wurtRAi0fNArUrOOu5+rVLcJq/+wJc+L30J\nDKnivGkoV/a/+Smvc0hOhtGj7ZbCPyZPhvffd84N26NAHMyZpIAQFVlKbIx0xmy1QQMVSe3EFPgV\nERGh4kGcUN525kxo1YrVCw+zYYMDPkt/8KRbsdiM5U8gIcC8So5/WsGxqiK+mrlfP+Bz/AAwoqIT\nhBA9gUeBC6SUpaKam5sQYjIwGaBFixakpqZW2b4q8vLyAjo/6tgx6v76KyfbtkXamAerxtdRVuaI\n6Ns2l19OfuvWHPaSPdDPxAzOPRc+/jia/ftjaNmygCZNivBHRDOvpdWCBeS1b0+uBSsQo66jY9Om\ntPj6a1YtX27bJCYvL4/9n39Os5Mn+fann5wzmfKD8267jeMNG3Lc/VlY8luRUlb5ACbW5FFNX61Q\n9ceG+xx/FNhSQfu6QAaQ7HXsMWBTdXJLKenfv78MhOXLlwd0vnznHSlByp9/DqyfAPH7Oo4elVsj\nu8p7Ws+V+/ebKlKtCfgzMZOjR6V88kkp1671q7lp11JcLGV0tJR/+pM5/ftg2HW8/76UY8ZImZtr\nTH+1YPny5VL26yflyJG2yWAUgXwuwDrpxz222hWIlPJdg3QVwCGglLMzKzTn7FUJQEugG/COEOId\n97EIQAghSoAxUkpfc5hzyMpSM/nzqvQPcAwpn8UzpXQdYp9glt01qg8cUFH8bds6YjXkF5GR8Mgj\natZqZ1qT7dvVRkywbKB7GD/e9qwDorhYOSDcc4+tctSKggK1h9S9u2Xldy39ZUopi1CpUEb6vDQS\n5Y3ly16gJ9DH6/EaKlljn0rOcQ5OT+PuRU4OTLldkE8cp2Ss/cFT77yjvNdsSM9Qaxo0gHbtznhA\n2UVGhnoONgXiwcasvPV27VLKt29f22SoNStXqp1/C+Om7JjazQAmCSFuE0J0FUK8gDJtvQYghJgj\nhJgDKn2KlHKT9wM4CBS6/7c+9LImZGWdKdbkcBznjrptG7Rs6ew6IBXRo4czFIgQKtV3sDFiBPz+\n97YNXxobq0rEXhCE1Sg8Ss/CjXR/N9ENQ0o5VwjRFHgYZaLahDJFeaoZBoe9xx+yslRGzyDAce6o\nQeCBVSE9eqh8YsXFZ2tkq9i6VX1wcXH2jB8IDRqolDo2kd+6Nbzwgm3jB0SzZsriYaErry3GZSnl\nq1LKdlLKulLK/lLKFV6vJUkpk6o49zEpZXA4t8+ZA9Om2S2FX3jcUSNFKbEi33531GBWIJGRqhyq\nXcyZo4o0BSO9eqnPPj/fluFj9+49eyYVTPTrZ+kKJEh2J4OUSy8NKltqcjLs2RfJ19/GkpUt7NtA\nP3pUpcAPRgVy/fUqqZ2dpsvISGjRwr7xA6FXL7UH4tnHsZKyMgbcdhvcf7/1YxtF375qBWpRYkWt\nQMxi+3ZYsMC2mVRtcblgcJ98XNLalAjlqFtXFcgJEvNfOaKj7S1+lZWlAkKdVh3RX3r3Vs92RKT/\n/DORBQXOroFeHRMmwLJlljnuaAViFp99BldfHXQKBFCeHFOm2Dd+XJzKLOrkOuhV8eST9tUwWbcO\n3ngjOL93oDzvpkxRedmsxmP6CSKrwVm0b69SElmkQCzfRA8bsrIgPt6Zdcaro2tXe5ParV+vfNqH\nDrVPhkDYuFHNoP9mQ+adjAwVN+Op0x5sRETAa6/ZM/aGDZTVqUNEsLo/e/jqKxVDFR9v+lB6BWIW\nwZTG3Zdu3ZT8p07ZM/6//gWTJtkzthF0767SqduxCsjIUN+7YMmBVRFlZer9szqp54YNnExICIq4\nrSp59ll47DFLhtIKxCyCKY27L926qR/v1q32jL91a3BuoHvo0UPdBO3Yh8jICJ4MvJXx2mvKhLXP\n4uqOf/kL2bfcYu2YZtC3L2zahCgqMn0orUDMoLRUReAFSRDhWXTrpp7tKG9bVgY//xz8CgSsDygs\nLVWKv2dPa8c1Go/8Vm+kX3QRR4IxgNCXfv2gpIR6FkQB6z0QMxBCBUNZlI/GcDp2hOeesyef0759\nynQWzAqkQwclf2mpteNGRqpVj1PqudQWjwLZuNG6UgjbtkFWFiJY8q5VRb9+5NCC1x5pzN+uMjeW\nKwTeLQcSEaE2ooMkieJZREerZHJ23MS3bVPPwaxAoqKUGc6ufZxg3HfzplEj9duxcgXy4YcwZgwR\nVit9E0hZlUAC2bx/6EoSEyElxbyxtAIxgZt6buCeNvPI2Vlgtyi1Z98++NqG6sGDBqkoajuz2QYr\nL7wAV10V/CsQUPEgViqQDRugc2eVCyuIycmBKVMjKCCWAhljelJUrUAMJiUF/pPRg3f2jiSxW11T\ntb+pzJwJl10GhYXWjluvHgwerGqhBzMffaScKHJ9q0Ebz5Ah7pLYX2xUK59gX4EA3H23tW7QP/4Y\n3PEfbqxOiqoViIHk5ChtXyyjyCWe/Hxhb0r0QOjWTdnwPSYlCxgyBCa3+4KcD5ZZNqZpxMSoX63J\njggpKfD995CeDolLXiGlwVRTx7OMSy5RgbhWcPgw/PJLSCgQq5OiagViII5LiR4InmAqizyxPDfC\n/+waTOJNQ4N35ebB44llYk4nz4SlrEzp+nwZy5S0acE5YfGltBRWrIDNm80fyxOB3q+f+WOZjCcp\nakQERESUERuLqUlRtQIxEKX9y9ufbU2JHgidOqlvoQUKxPtGeIKG5JfWDd6Vm4d27VRKFhNdeSuc\nsETJ4JywVMRll8Gbb5o/zkUXKY+vUHDhRSVF3bsXXnwxjawsc6uKagViIC4XzHriALGcom5Ekena\n31RiYlQciwUKJKRWbh4iIpQZ0EQFUqG5oqxOcE5YfImMVKu4jRvNHysqSmUBDla3+wpwuaB791zT\n7z06DsRgkh9wMfLqPLJ3l5LQLUiVh4d33rEkLbjjilkZxXXXmbqJ7jFXTJqk9s2jo2HWrIjg/s55\n06uXSkoqpbmOAU88ofKuXXKJeWOEKHoFYgKuDvUZfHFs8P+Qhw61JCuq50YYJYqJ55j9xayM4qGH\n4O9/N3UIj7li5QppurnCcnr3hkOH4MAB88bIy1N5o7791rwxQhitQIzm2Wdhxgy7pTCGAwdUXiIL\nchIlJ8PuPZEs/rTI3mJWRlNaarortMsFgyf3xPXMA6aOYzm9eqlnM81YGzeqFU4IeGDZgVYgRvPu\nu6qgSyiwbx9MnQpr1lgynKtVBIOvah78Kw8PBw9C/frw1lvmjnPqlNqrql/f3HGsZuBAchb+wJro\ni8xzqAghDyw70ArESEpKVCCXJxlhsNO5s7I9W+HKm58PEydapqws4ZxzVHVFs5MqevJfBXsdCx9S\n/luP1lcNYPjIGPNScvz4o/qcWrUyofPQRysQI9mxQ+3+hsoPOS5O7WRbUZ9640aYM8dce7fVCKE8\nicxWIJ7PJ9jTuHtxVoyLWSk59u5V5qtQiN63Aa1AjMQzUw+VFQioa7FiBeKpgNi/v/ljWUmPHuoG\nb2Z+qo0blQuWHWVgTcIy1+4vvoAFCwzuNHzQCsRIjh1TmUS7drVbEuPo1k2Z5UpKzB1n3Tpo3hza\ntDF3HKvp0QOOHDE3KnLgQLj//rPvuEGMpa7dMTEmdBoeaAViJDffrG4WobSZ+cc/qs3gOiaHDK1b\np1YfoWZKSEpScQaRkeaNceONprsLW413So765BErCox37Z4/H66/Ho4fN7DT8EIrEKMJtRtgs2YQ\nH2/uGKWl6n07/3xzx7GDHj3gkUcYcnVzlTHX6IXIvn2htW/khSfG5cupn5Al25F8ibHu5POnLOGL\nT06Rc7KBof2GE1qBGEVpqUpD/uGHdktiLFLCI4+o2ZpZREaq2g+PPmreGDaS8uoJ1n5XpjLmGu1N\nNGMGtG1rfdp9i3C5YPDtvXE1MzYzdMpbRSQffoFryz4msUNE8CfvtAmtQIwiOxu++w4KgriIVEUI\nobyj/vtfa8YKMXJyYMqdUZTKCHO8iVJTVRLAunUN6tCB9Oyp3rCkJEO6y8mBKdMiySeOUzLO9KJL\noYxWIEbhcaUMJQ8sD2Z7Yt17L0yYYF7/NpKdDVF1yntgGeZNdOyYCoQz6MbqWIRQq1QpDfFmy86G\nKFl+xRb0yTttQisQo/DcYEPJA8tDt24qWM2setFffaVuhiFIQoIqMOaNYd5EK1eqQIlQVyCgTJzt\n26saIQFi6mcSZmgFYhQZGXDuucFfirUiunVTprmdO43v++RJVTQo1OI/3LhcMOvBLGI5RXxcsbEp\n/lNTlekqROpYVEm7drBnDyxeHHBXLhfMejuKiAi1sAnqsgs2oxWIUbRpA5dfbrcU5tCtGzRooFxi\njCYtTc2iBwwwvm+HkHx/c7JIZPFNHxqbMfeuu2DevPCIY2jYEIYNg88/D7yvzEySxxWrLMYrCb0s\nxhZiiwIRQkwTQmQLIQqEEOuFEMOraHutEOJLIcSvQogTQojvhRBXWimvXzz9NMycabcU5jBokPKV\nv/BC4/tet049h+gKBIBGjXC9+RSD/3KxsbPctm1h7FgDO3Q4Y8ao4u979tS+j9JSZfKbPFl5eA3W\nK49AsFyBCCFuBF4A/g70BVYDi4UQ51VyykXAMuByd/vPgU+qUjqWY2aaCicQEWGeh5TLpQovhXoy\nu1tvNTbKfv16eOMNlYk3XBg9Wj0HYsZauRJ+/TV0rQUWY8cK5D5gtpTyDSnlZinlncB+YGpFjaWU\nd0spn5ZSrpVSbpdSPg6sB662UOaqWbgQWra0JmeUXTz7rCp9ZzQ33qjMMKFOUZFyhzYq2/AHHygT\nVkQYWaG7dYO77w7M03H+fGXy8ygjTUBY+u0TQkQD/YEvfV76EhhSg64aAEeNkitgMjOVE3nr1nZL\nYh6//KJu9GVlxvVZUhJ6cTOVEREB99xjnJlz+XJlfwmH/Q8PQsDzz6tKmbWhrAw++QRGjQqp+ud2\nYnVN9GZAJOCbe+EAMMKfDoQQdwBtgApjR4UQk4HJAC1atCA1NbW2spKXl+fX+V2WLaPROefwnac4\njcPw9zqqomVkJJ1PnmTNRx9RaJDROP6nn+h9331sfOYZjvfp49c5RlyLXXQZMICmCxaw+uuvkZGR\ntb6WOidOMDQtjZ0TJ7LLAe+FpZ+JlMTt3ElZbCwFNfweNsjMpP/evWyeOJEDlcgbzN8vXyy5Fiml\nZQ+gFSCB4T7HHwW2+HH+dcAp4Ep/xuvfv78MhOXLl/vXsF8/KS+9NKCxzMTv66iKlStVGNfnnwfe\nl4cZM1Sf+/f7fYoh12IX8+ap63VfQ62vZcEC1c+KFYaJFgiWfiYnTkgZFSXlH/9Y83NLStT3+Pjx\nSpsE9ffLh0CuBVgn/bjHWm1APQSUAr5Th+acvSophxDiOtSq4yYp5WfmiFcLyspUHEMoRqB74wmQ\nNHKfZ/16ZfYLFzeYyy5TcRuB1p/IyFDBC6GYfLI66tdX3oC1ceeNjFSuwKEYq2UTlioQKWURagN8\npM9LI1HeWBUihLgBeA+YJKV01o6rJ5HOZZfZLYm5NG2qbM9G2tzXrQvp+I+zqF8fLrkEtm8PrJ/p\n09WeWyjnv6qK0aOVEt292/9zNm1STgf7jM3oG+7Y4cIxA5gkhLhNCNFVCPECyrT1GoAQYo4QYo6n\nsRBiHPA+8BCwQgjhcj+a2CD72dSrB889pzbmQp1Vq+COO4zpKzdXZVcN5fiPipg3T3ntBUo4z6LH\njFHPNXHnnTsXXnklpIpuOQHLFYiUci5wD/AwkAYMA8ZIKXe5m5znfni4HbXZ/zzK3dfzsCA9rB8c\nPhyyqbRNRUr497/DKxAOlOkJah87tGQJXHEF7N9vnEzBRpcuKoiyJgpk/ny46CI45xzz5ApDbHEi\nl1K+KqVsJ6WsK6XsL6Vc4fVakpQyyed/UcEjqaK+Lef++6FjR7ulsIbPPlPBcIFEAnuIj1fvXd++\ngfcVbPz1rzDS14rrJ0uWwNdfQxNnLMBtQQj49FMVV+MPmzerx3XXmStXGBJGUUgmkZEBnTvbLYU1\nNGxIzt4S1szbG3jthPXrw9ceHRsLX39N9KFDNT83NRWGDAnf/Q8Pffr4b8bzFEO75hrz5AlTtAIJ\nhHDxwHKTktGXRLK4+L4+gVfWGz/euP2UYOOqqwBotrpSv5GKOXwYNm4Mj/Tt/vDcc+Q8PZs1ayou\nBlGLe/EAABmLSURBVJWTowL/c07UU6bSUE+XYwNagQTC7t0qHXn37nZLYjo5OTDljw3JJ44CWTew\nKm7Hj6sN9HDywPKma1fo0IGm335bs/M8tTB+8xvjZQpCUt4uJmH6jQwffnap4JQU5SE+fDgkvnQv\nKTcY4LigOQutQALBExMRBiuQ7GyIiiqfULHWVdw8Efvh5oHlQQi46ioab9gAJ074f15UlNoIHjjQ\nPNmChJwcmLL1XgqIPatUcE6O+rusDHPKCGtOY3Uqk9CiSxd45hlVsznESUiA4uLyx2pdxS0cUrhX\nx7hx7Nm3j/MKC1WtFX8YOzb8vNYqITsboupGkO/1nYyOlmRnCzh8mKioJuTnC6/X1DnhErNqFXoF\nEgiJicqTKD7ebklMx+VSVdsMqeK2bh2cd154u1QOGEDW5MnQrJl/7QsL1VRaA7gnNKWR5Y4VFQkS\nEiDhyVsozs33eU2XrDUDrUACYfXqsPLHT05WRQlXppaSNWcVyZdWmX2mcp56yn8XzBBGFBerevC+\nS7uK+N//oFEjVVBJU+WExvXgRGaN+pS6FNCAXGJjynTJWpPQCqS2SAmXXgr/+IfdkliKywWDXdm4\nrh8O771Xu07at1e2/DCnyfffq+/QypXVN05NhTp1wsdl3A9OT2h8y9Jeey3Ji8ezc38MX6xuSFZ2\nhC5ZaxJagdSWX34JGw+ss+jQQXlQffBBzc/dvBlef12lMglzjvbvr3KL+ZNcMTVV5SKLjjZdrmCi\nqrK0umSt+ehN9NqSkaGew8ADq0LGj4f77lPuuJ06+X/ewoXw4IM6Khgoi41VEekLFqhCSZWUDc7J\nOEx2ej0SLr/8rDTWpshVVsahQ4c4duwYpaWl1baPj49n8+bNFkhmPuF0LTExMbRp04aoAPKDaQVS\nW8LIhbdCbrxRORB8+CE8+qj/561fD+3aqey+GhVUuHAhOcsyyY7rTkJC+RlzSgrcOrEhsSym+LkG\nzOqG6eaYPXv2IISgXbt2REVFISpRbB5OnDhBA389yRxOuFyLlJLDhw+zZ88eEgLwLtAmrNqSkQEt\nWoTvjbBVKxURvXRpzc4LtxTu1TF2LClM4LyRnc4ExM2RsGgROf9bz5QpUCyjyKUR+YWRlsQznDx5\nktatWxMdHV2t8tAEJ0IImjZtSkGAJaW1AqkFOTmwZtTj5LzsrNIklvPee6o2t5/kbDnGmqzm5HS6\n0EShgosc2YIpdd+lWEadCXqbVEjOFbeR/fyCs7KP1zp4s4ZEROhbQ6hjxORAf0tqyOkUCePPJfGm\nYYHlgwp2WrVSnkF+kJICbbo1YBSLSXxmWni/b154AuK8iaaI7L+8RcLbjxgXvKnRmIBWIDVAp0io\ngDlzlHdQWVmlTTzvW6mMVKaYImtMMcGAivAvXxukKKYBCf93Oa5zo5g1S8U4xMcHGLwZZhw9epSd\nO3cye/Zsjh49arc4IYtWIDVA5YMqf8wqk4JjiYpSAZWrVlXaJDsboiJKyh0L+/fNjQqIE8TGlBHf\nULqVhDitJJKTVYzD4sU+sQ6aKlm/fj0vvfQSixYtYt68MDc1m4j2wqoBhuaDChWuvBLi4lRMyIUV\n720krJ1L8ckr8P66hf375kVyMowcGUF2Nmd5YYE7ulqvOmqMrG3VR43f6BVIDXC5YNaLBcRyivio\nk9qkAKom/JVXqlrfFaXkyMjANf1mZnV5nthYqU0xlaCD3vzn3XffpX79+tSvX5+YmBgiIyNP/9+o\nUSMKCwvp378/d911F2PHjuW3v/2tKXJMmDCBli1b0rBhQzp16sSbb75Z7vWXX36ZAQMGULduXSZN\nmlRlX0eOHOGaa66hXr16tG3blg9qE6RrA1qB1JDk0nfJIpHFL+3QJgUP48erYkdffVX++MmTcMMN\n0KAByctuJitLaFOMJmAmTpxIXl4eeXl5/PnPf2bs2LGn/z927Bh169alcePGtGvXjkmTJtG4cWNT\n5Jg+fTo7d+4kNzeXzz77jIcffpj169effr1Vq1Y8/PDD3HLLLdX2dccddxAdHc2BAwd4//33mTp1\nKhmeYGUHoxVITdm8GdeAcxk8uaeeLXq47DK45RYVF+PNnXeq1CXvvw8tW+pZtsZw0tLS6N27ty1j\nd+/enbru0sJCCIQQ7Nix4/Tr1157LVdffTVNq4kVO3nyJPPnz+fJJ5+kfv36DBs2jCuvvJKUKlwV\nn3rqKaZOnXr6/6NHjxIVFUVBQQH//Oc/ad26Na1ataJz5858/fXXAV5p5eg9kJry/PNQUFBp2omw\nJDoa3nrr7ONXXqlqpowYYb1MmrAgLS2NCRMmBNTH2LFjWVWJE8iwYcNYtGhRpedOmzaN2bNnk5+f\nT9++fRkzZkyNx9+2bRuRkZF08koJ1Lt3b7755ptKz0lPT+c3XpUp09LS6Ny5M7t27eLll1/mhx9+\noEGDBhw+fNivdDS1RSuQmnDwIDRvrhLgac5m82ZyciC7TkcSOtbBdfXVdkukCWFyc3PZuXMnffr0\nCagfbwVR01Qmr776Ki+99BJr1qwhNTX19IqkJuTl5RHvU1MoPj6eE1VUq0xPT+fee+89/b9nJRYZ\nGUlhYSGZmZn069ePdu3a1ViemqBNWP6yY4eKIHz/fbslcSZlZaQMeZXEEYmMSson8bwSHSwYSiQl\nnf149VX12qlTFb8+e7Z6/dChil+fO1e9/ssvtRJp48aNNGjQIKBcTkYQGRnJsGHD2LNnDzNnzqzx\n+fXr1yfXJzt1bm5upYqsqKiIHTt20NOrEurGjRvp06cPHTp04Pnnn+exxx6jffv2jBs3jn379tVY\nJn/RCsRfXn5ZPXstGzVnyDkYwZS8Z8kvq0tuWQPyi+voYEGNqaSlpdGrV69yKTnWrl3L4MGDufDC\nC/nd735HsR/FukaPHn3ai6tly5an/65fvz6jR4/2W56SkpJyeyD+0qlTJ0pKSvj5559PH9u4cSPd\nKykVkZmZSevWrYmLiwOUu3JqaurpvaDx48ezatUqNm3ahBCCBx98sMYy+Ys2YfnDiRPw9tvKo6hV\nK7ulcSQqJUck+V7xgroOdQiRmlr5a3FxVb/erFnVr597bq1ESktLO8t8de6557Js2TJiY2OZPn06\nCxYsqNaNd/Hixaf/9teEdfDgQZYtW8bYsWOJjY1l6dKlfPjhh+Xcb0tKSigpKaG0tJTS0lIKCgqo\nU6cOdXzS/9SrV49rr72Wv/71r7z55pukpaWxYMECVq9eXeHY6enpHDx4kB07dtCqVSueeuopdu3a\nRbt27di6dSt79+5l6NChxMTEEBsbS1kVWSICRa9A/GHOHFUA6a677JbEsSQkQHGZb41qHSyoMQ+P\n2cabli1bEhsbC0B0dLRpSSGFEMycOZM2bdrQuHFjHnjgAZ5//nmuuuqq023+9re/ERsby9NPP817\n771HbGwsf/vb3wC16vn73/9+uu2rr75Kfn4+zZs353e/+x0zZ86sdAWSnp7OZZddxujRo+nQoQMt\nWrQgMTGRp556isLCQh566CGaNWtGhw4dOHjwYLlxDEdKGbKP/v37y0BYvny5+qNnTynPPz+gvuzk\n9HWYzJw5UsbGShkfr57nzDF+DKuuxQqcei2ZmZk1ap+bm2uSJLVn586d8oILLpBFRUU1Os+J1+LL\nqFGj5Lx586pt58+1VPZZA+ukH/dYbcLyhy+/hAMH7JbC8aiUHFSakkOjsYLc3FySk5OZPXt2QNX2\nnEp6ejpdu3a1WwxA74H4h05G5Df6rdLYSUlJCePGjePRRx+lc+fOdotjOEePHuXgwYN07NjRblEA\nvQdSJbG7dyt3wyBIKaDRaODDDz/k+++/58knnyQpKYm5HlfhEKFx48YUFRU5ZmWlVyCVkJMDOW9l\nkrMmC1ezZnaLo9Fo/CA5OZlknWjNMmxZgQghpgkhsoUQBUKI9UKI4dW0v8jdrkAIkSWEuN1M+VJS\nIDFBctOK6SSWbSflyxbVn6TRaDRhhuUKRAhxI/AC8HegL7AaWCyEOK+S9gnA5+52fYF/AC8JIa4z\nQz5P9bz8AkEu8eSXRuuAOI1Go6kAO1Yg9wGzpZRvSCk3SynvBPYDUytpfzuwT0p5p7v9G8C7wANm\nCKeqDpYvRKOr52k0Gs3ZWKpAhBDRQH/gS5+XvgSGVHLa4ArafwEMEEIYvpOkqw5qNBqNf1i9id4M\niAR8gyoOAJXl/HYBSytoX8fd337vF4QQk4HJAC1atCC1qhQKlXDPPc2ZMaMzkZFllJZGcM89W9my\n5SBbttS4K0eQl5dXq/fBiehrMZ/qMsH6UlpaWqP2TibcrqWgoCCg76BdXli+xYpFBceqa1/RcaSU\nrwOvAwwYMEAmJSXVWLikJJW1ZP78jVx3XT9crm5Atxr34xRSU1OpzfvgRPS1mM/mzZupV6+e32lA\napoC3cmE07VIKYmJiaFv3761HsPqPZBDQClqVeFNc85elXjIqaR9CXDYUOm8cLmge/dcHRSnCTvq\n1avH3r17KSoqQmW10IQaUkoOHz5MTIC1jSxdgUgpi4QQ64GRwMdeL40E5ldy2hrAtzLRSFSulupz\nNWs0mhrRpk0bDh06xK5duygpKam2fUFBQcA3IqcQTtcSExNDmzZtAhrDDhPWDCBFCLEW+BblZdUK\neA1ACDEHQEp5k7v9a8D/CSGeB2YBQ4FJwO+sFVujCQ8iIiJo3rw5zZs396t9aur/t3fnQXKUZRzH\nv79sOGIQwxEQQwwSgiIospISRQ4PPBAVEUUtQCkQubygxHgglJaAKKWhSryIIiKIsUQjogjK4YlE\ngkY0CgSCIJIAQWIgJCSPfzzvWOOym52ZnU3P7Pw+VVub7untft70TD/9HtPvdSNqBukkLktzNngC\niYjLJG0FfBzYDvgzcGBELCmbPHPA9ndKOhD4PDnU95/A+yJiqBqLmZltAJV0okfE+cD5Q7y2/yDr\nrgf6RzksMzNrgh+maGZmLXECMTOzlmgsD9OTtAxYMuyGQ9uaHHrc7cZKOcBl6URjpRzgstRMi4jJ\nw200phPISEmaHxF7Vh3HSI2VcoDL0onGSjnAZWmWm7DMzKwlTiBmZtYSJ5D1+2rVAbTJWCkHuCyd\naKyUA1yWprgPxMzMWuIaiJmZtcQJxMzMWuIEYmZmLXECsY4nScNvZWYbmhPIAJJmSNq26jhGaixc\ndCU9DSDqRnpI6sr37GBxj4VzNFbUzoXPSXO68sPYbpK2kXSKpHuA7wJXSJon6UhJE6uOr1mSxkdE\nSHpqWe668yxpJvCdcl5eLGkCQESsK9MBdA1JOwJvkvSM+vW1xNhN50dSn6SdJB0v6aCy3PUX3dq5\nqDsn6vZybYj4PYwXkHQhOen5FeQ0uVsBLwB2Ae4BzomIqysLsAmSdgU+BLwM+ANwekQslKToopMt\n6UxgFnAdsBGwCLgGmAScC2weEesqC7AJki4DHgdOiohHJE0HXgqsBC6PiLWVBtgESScBJwF9wCPA\n+yPiV6VMd3bLOakpyfuNwGTgKcC9wPURsbTSwFok6YDyz/kRsXzUj9dF15RRUbL0CnJSqxvq1k0F\nXgS8G5gGHBYRt1QWaIMk3QQ8BPyMnAp4Z2DfiPhb3TYTI2JlRSE2RNLewLfIZDEJeBUwAZhCnq+P\nAAsi4q6qYmxE3fvrgIj4raQTgVOB/wBbkq0ApwEXdPrFt5TlfjL+PwKnkDdcmwN7ANsCs4HzIuLR\nquJsVKmhzyFvttaRN4sBPAZcD1wcEYu64eartJScCRxOJsKVwHsj4tJRjT8ievoH2BVYCOw1xOsb\nA/OBs6qOtYGyvLOUZVJZFnA1cGFtufyeDUyvOt4GynMsmUQEbAq8HlgD/BW4kfyQd3Q5gFcCfyEn\nb3su+XToY8r7biZwFvB3YJeqY22gLIeTNcFxZXkGsBq4tLx2OnkRfknVsTZYno+RiXBmWX5OKceX\ngZuAecDkquNssCynlM/EoWQCORdYULsWlG0E7A70teu4XdP2OooWA0uBz5cO9P/7P4mI1cA3gddW\nEVyTDgF+HBEPS9o48l1zJrC3pBkREZL2I+9M7qg21PUr5+EbwCbAByNiFXkRvg84iHxMw22dXg4y\nYTxM3p33k1M4z4mIWyPiJuAL5DTN3fD+2pFMhrW29cPJC/AREXExOcvorWSTUDd4DfDNch6IiEWl\nHCeSF+RdyBuYbnAMWYv9XmTt7yyyNvWhum0OAc6NNjaZ9nwCiYjHyDuRCcBFwJGSptY6zyU9BdiP\n/OB3LEmbkHfn/y5V1tWlM/1a4E7guLLpscDcquJsVESsi4g1wFeAEyQ9HTgB+H5E3BERcyLimGqj\nbMjt5Hn5KtkU+ijZpwNARNxPJpCplUTXnF8A+wKflnQ68C7gyoh4AiAilpFNWptWFmGDJI0nP9Nv\nljS5rOuT1BcRayObs48Dtpe0e5WxDkfS9mQT3I21dRHxAFkLOULSlLL6RLK22z5VV7065QfYDbiM\nbP98APgR8HXg7nJinld1jMPEL/IO95Tact1rrwOWAzuQd8N7Vx1vk2U7AbitfEj2LOvaVg3fAPFv\nB/y0vI/WAZ8p52o8sD/ZZzVoE2on/ZAd5x8Gfgv8mLzxmg9MKa9PBZZ1Q1lKvHsBd5Tzse0gr08l\n+6qmVB3rMOXYFfgNcFRZrjVVjyvn58NkP+IaYId2HrvnO9EHkrQNecE9GFhF3qXMjYhFlQbWpPqO\nM0kbAZcD04GJEfHMSoNrUqldnUPe2X4gstbYVUqH7VuBs8lRfreQneh95Pvr5ArDa0oZUh1kTeqH\n5Milh4B9gPsi4nUVhteQ0kQ6DjiKbOYdD3yPvIn8B/B8ss9tl4iYWVWcjZK0M7AiIu4rgx36IuKJ\nMmjjbcCVwNERsVNbj+sEMjRJ46LDR8YMp5ZIJL0d+DZwRkR8suq4miVpY2CziHio6lhGStI04NXk\nRfg24FdRmoG6Tfluy6nksOR5wCURcXu1UTVH0iSyOe4d5PD9FeSw69+Tg2duHPqvO8fA0VYlSW5G\nNj32A8dGxAVtPaYTSG8odyV7Aosj4sGq47GxpRuGutZI2py8Wx94sd2UvODuBqzshsQxWFkG2WYW\nWcua2O7auxOImfUUSV8haxe/B5ZExCODbLNFRCzv9MTYYFkmksN572378Tv4/8bMrK3qmnIfIftt\nrgauAv4E3BsRj0naDLgYOC0iFlYW7DCGKMtPybL8s64slwAfjYi2jyR1AjGzniHpa8BaclDGIeSX\nb6cDfyM7mn8OPBuYHREbVxVnI5ooy3kRsdFQ+xlRDE4gZtYLync/TiWfozarbv2u5COLDiX7QSaR\nXzA8upJAG9ApZXECMbOeIWkL8jsfi8rIvjUDOtMPIx/N0h8d/uy7TijL+NHYqZlZJ4p8Qu3y8u/V\n8L8RWIp8xMfmwKpOTx7QGWVxAjGznjbgu15PJR8K2ZU2dFnchGVmVpSnNqzt9i8Qw4YpixOImZm1\npOefxmtmZq1xAjEzs5Y4gZiZWUucQMzMrCVOIGZm1hInEOspkg6W9KTJmySdIakjhiRKulBSlJ/r\nRmH/H6/b/z3t3r/1DicQ6zUHA4PN/ncB8OINHMv6/IuM54RR2Pc3yr6vHIV9Ww/xN9HNgIi4B+ik\nu/HHI+J3o7HjMi/EvZKWjcb+rXe4BmI9Q9KF5COvp9Q14dxVXvu/JqzasqTnSLpK0kpJd0s6qrx+\nhKRFkv4j6VpJ0wc53u6S5klaLukxSb+WtM8I4h8naYWkTwxYv0WJ9Z1leWdJl0taKmlViXtueYKr\nWdv4DWW95FPAZGAm8Iay7vFh/mYu8DXgc2Rz0tclzQD2B2YBGwGzyUl7XlT7I0n9wC+BBeTjtR8F\njgOukfSSiPhDC/HvTE65umDA+j3K79r6K4CHgeOBB4ApwIH4htHazAnEekZE3FGabVY30Tz02Yi4\nCEDSfOD1wHuAZ9WmD5W0HTBb0rSIWFL7O+Bu4OV1T0q9CvgzcBrZF9Os/vL75gHr9yAT4V8lbQ3M\nAN4YEfPqtrmkheOZrZfvSMzW7ye1f5THZy8Ffjdg7ulF5fdUAEkTgP3I2ss6SeNL85GAa4B9W4zl\nhcDSQea27gdujYg1wIPAYuBsSe8utSWzUeEEYrZ+ywcsrx5iHeQMcABbAn1kTWPNgJ+TgC3KvA3N\n6ufJtQ/IGsgCgDKh0AHAfOAs4O+SFks6voXjma2Xm7DM2u9hYB3wReCiwTZo9hHbkgS8APjSgPXb\nkPNef7Fu34uBI8vf7E4mrfMl3RURP8GsTZxArNc8DkwYzQNExEpJvyQv3je3aT6G6eT81msHrH8v\n2ZLwpFnnSm3klvLFyaOB3ahrkjMbKScQ6zV/AbYsTTrzySk/F47CcU4GbgCukjQHuA/YmmyG6ouI\nWU3ur9aBfoykf5B9Ma8ihyUD7CnpZrIDfTZwGXA72ZT2LuAJ4Bctl8ZsEE4g1msuAPYCziTv6JcA\nO7T7IBFxs6SZ5JSi5wFPA5aRfRhfbmGX/cBD5NDhs8nhvD8A3gJcChwWEbMl/Ysc/XUysD2wClgI\nHNTi0GGzIXlGQrMOU77wuD+wE9kStVbS1eTCAW3Yv8iayRzgFRGx/Uj3ab3Jo7DMOtM0ctTWz8vy\nHkC7ahAfK/s+sk37sx7lGohZh5G0A9lfArCCbIa6C3hrRMxtw/63I7+dDvmlyj+NdJ/Wm5xAzMys\nJW7CMjOzljiBmJlZS5xAzMysJU4gZmbWEicQMzNriROImZm1xAnEzMxa4gRiZmYt+S/SjYhjyTkS\nTQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x11a27b2b0>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a: 0.47 ± 0.01\n",
-      "T2*: 31.32 µs ± 2.31 µs\n",
-      "f: 319.07kHz ± 375.942kHz\n",
-      "phi: 3.13 ± 0.02\n",
-      "c: 0.47 ± 0.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# arrange the data from the run\n",
     "\n",
@@ -425,10 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Measurement of $T_2$ Echo\n",
     "\n",
@@ -439,11 +324,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -480,24 +363,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running on backend: ibmqx4\n",
-      "status = RUNNING (20 seconds)\n",
-      "status = RUNNING (40 seconds)\n",
-      "status = RUNNING (60 seconds)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run the program on hardware/simulator\n",
     "result=Q_program.execute(circuits, backend=backend, shots=shots, wait=20, timeout=600)"
@@ -505,33 +375,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ0AAAExCAYAAACnAX83AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xd4VFX6wPHvm5BApBchiAUQUOyIip3gigXLig11jeIu\nRVAsqKv+xLLrYl8FCxixsGABRWy7oqgQcUFAWMEoKioBRA1FQVpIfX9/nBuYDJNkMsnMTWbez/PM\nk8yde889Z24y75xzTxFVxRhjjImFJL8zYIwxJnFY0DHGGBMzFnSMMcbEjAUdY4wxMWNBxxhjTMxY\n0DHGGBMzFnSMMcbEjAUdY4wxMWNBxxgTN0Skk4i8KSLrRURFZKLfeTLlNfA7AyZ2RKQJ8Dvhf9lo\npaobo5glEwdE5AjgPGCiqq70OTsTgcOA0UAe8ENVB4hIM+B6oD/QFUgGVgL/Bh5R1XVRymtCEpsG\nJ3GISAvg7KDNw4DjgZuBtQHbC1T1tVjlzdRfIjIQeAHoo6rZPuajIZAPPKmq14V5TDfgfWA/YDow\nGygCjgUux31JO1tVF0Ql0wnIajoJRFU3AS8GbhORG4EdwFhVLfYlYwlERJKBhqq63e+8xKF2gAC/\nhbOziOwBvAN0AM5R1f8EvPyMiIwDPgTeFpFDrcZTO+yeTgITkRTgYOCLaAccERnotbH/QUTuEpFV\nIpIvIgtE5Fhvn94i8l8R2SYiv4jInRWk1VBE/k9EvhKRHSKySUTeEZEeQfs1FZF/eOfYICIFIvK9\niDzgfeAE7ttIRO4RkW9FZLuXZo6IPBywzz1eGTqGyNNKEcmuoMynisidIvIDLsBfXM1y+PHelZ3z\nFBG5WUR+8N6/5SJyZeB7gqvlAMz2jtl5LyWc97UqItJGRJ4SkR9FpND7+ZSItA7YZyKwynt6d0A+\nMipJ+i9AN+CxoIADgKouAv4PaAvcEm5+TeWsppPYDgYaAp/H8JwP4NrMxwKpwE3A+94H2XPAM8BL\nuA/mv4tIrqrurJ15gfI9XJPgZOBJoDkwGJgrIid7HxbgvsEOAl4HXgaKgd7AX4EewOkB+XoK+DMw\nCXjMy2NX4JRaKPMjQAowAdgMfFvNcpSJ5XtX5j4gDcgCCnDNsRNF5HtVnYtrkmoPDPH2/do7ruxe\nSo3eVxFpDswDugDPA//DXbthwCkicoyqbvHyt8Q7xxtevgjITygXej8nVLLPRGAMcAEWeGqHqtoj\nQR/AVYACQ2JwroHeuf4HpAZsP9fbXgwcHbA9FfgF+DQonRu9/U8P2t4MWA1kB6WREiIv93ppHBOw\n7Tfg3SrKcI93XMcQr60MPHdQmb8F9qhBOfx478rO+XnQOTvggs8rIfbNCPG+VPm+VvGej/bSHh60\n/Rpv+70B2zp62+4JM+1fgc1h7Jfjpdsk2v8nifCw5rXEdqT3M5Y1nfGqWhjw/BPv53xV/axso7fP\nQty34kCXA98Ai71mlzYi0gb3QfsBcKKIpJWloapFACLSQERaevt+6KXVKyDd34GDReSQ2ilmOeN1\n93s4YZcjKJ2YvHcBxgWeU1V/ApaHSLsiNX1f+wPrcbW4QFnABu/1SDXD5a8qZfs0rcG5jMea1xJb\nD9y35JzAjeJ6AT0J/AHYE/et+QlVfaIWzrki8ImqbhQRgNwQ+24EWgdt645r7llfyTnaAD8CiMhw\n4GpcU2Lwl6yWAb/fgGtyyhGRFbheTO8A76hqaSXnCsfyENuqVQ5PTN+7UOf0/Irr7RWOmr6vnYBF\nGnTPUVWLReRbdn1xisRmXOCpSjOgFBfkENfB4Bxc0+QW4DXgr0FfCEwFLOgkKBFJAg4HvlbVHUEv\nN8CNcTgN96FzGO7ewVpVfbWGpy6p5vZggguSIyvZZz2AiIwE/gnMBB4HfgYKcU1EEwkIQqr6ltdB\noB/uvs+puBvNn4jIqd4HSmXjCyr7XwrVUy3scgSI2XsXRtoSzgnDfF/98iVwsoh0UdXvQ+3gdTg5\nAFhVVmvGfSG7RVW3iciewKu4Dgf3xCDP9Z4FncTVFWiCu09QjqpuAwJ7Py0RkXeBE3H/YH76Dlf7\nmhXGN+VM3L2WMwP3FZEzQu2sqr/hupS/KK4K8QCu08Efcd9my7ritvLSLUuvEe5mesgPrlooR22J\n1jkrHewXxvtamRXAASLSILC2IyINcD3PQtXEwvU6cDKus8ltFexzBa75cWeHDFVdFrRPKeE3NyY8\nu6eTuMK+n+P1ejoR+CKqOQrPJCCdCr6ti0i7gKcluA9ECXi9AUEfMCKSLG7g7E7q7iCXvTetvJ9l\nzWSnBp32Rqr/v1SdctSWaJ1zq/ezVeDGaryvlXkTFygHBW0f7G1/o9q53eVZ3DW9MdQXERE5Ergf\n17z8VNBrt4nIVmAdrsVgTA3ykVCsppO4ysZl7FbTCeFJYBPuQ8tvY4G+wMMicgowC9c2vy/uHtQO\noI+37zTch8YMEZmOa5u/DDfiPFBT4BcReRv3gbgOdy9hGO7eyDvefh/ibsT/3RsjkosLxsfitfdH\nqRy1JVrn/Az3bf8OEWkJbMO9N98S3vtamYeAi4CnvCDwOe5v9y9e+g9FkF8AVHW7iJyL60b+HxF5\nHcjG3ec8BldT3gicq6prg459AHhARLoDf8IFJhMOv7vP2cOfB663UinQrIr9HsXVcNrU8HwDqbhb\nreLm7QrePhHvy3HQ9gbAdbgPu23e4zvcGJXTAvZLBm7HNXsV4AYPPoS7ob6zay2u+eR+XI+vX719\nV+LGhXQNOnc33IfUdlwgfhV3j2glFXeZ3q3M1SyHH+9dZefMBlYGbbsSWIa7Z6be+cN+X6v429kT\nGAeswX1hWIOrebQJ2q9j4HWtRvrNcM3Jn+Nqbeo9vgRahHH8RcDsaP2vxtvD5l4zFRKRMbhvwKeo\namU9noyJG14T7Gu4SUxvUtVHq9j/MuBhVe0Qi/zVd77c0xGR4SKS603DsVhETqpk394iMk9EfhU3\n9cc3InJziP0uEJFl3lQdy0SkJv33E56IPI67d2EBxyQUdR0WBgDvAv8UkWFlr4lIc3FTBLUQ51Bg\nFG7SUBOGmNd0RGQArifIcOC/3s+rgINUdXWI/Xvieobk4Jo0TsANDLtFVcd5+xyHGyh3N276i/OB\nvwEnqM0OW20ish+uGaQA175d5hNVPdOXTBlTB4hbBmE6riNOKu4+1XTgbnW9Pk0V/Ag6C3ATTA4O\n2PYdME1Vbw8zjem4qfcv9Z5Pxa390jdgnw+B9WX7GGOM8V9Mm9dEJBXoiRusF2gmbhLCcNLo4e37\nccDm40Kk+X64aRpjjImNWN/TaYPrUbQ2aPta3PiBConIGhEpABbh5oN6OuDl9EjSNMYYE1t+jdMJ\nbtOTENuCnYQbQX8s8KA3bfvkSNIUkSG4qdhJS0vruc8++4Sb73JKS0tJSkrc8bWJXP5ELjskdvmt\n7K7sy5cv36Cqe1Y3jVgHnQ24UeLBNZC27F5TKUdVyyY1zPFGTt+Dm0gQ3DxhYaepqs/gzVp71FFH\n6aJFwUuIhCc7O5uMjIyIjo0HiVz+RC47JHb5rewZAIjIqsr3Di2m4Vrd5H6LcaOiA/XFLdQUriTc\n4mNlPq2FNI0xxkSZH81rjwKTRWQhMBc37fxewNMAIjIJQFWv8J6PYNeUGuAm6LsZN0K5zFhgjojc\njpuLqT9uOo8To10YY4wx4Yt50FHVqd68VaNwM/N+CfRT1bKq2r5BhyQDD+KmuCjGLYN7G16Q8tKc\nJyKXAP/Ajc/5ARhgY3SMMaZu8aUjgTeoc1wFr2UEPR9DGDO4quo03ASPxhhj6iibZboCpaWlbNiw\ngU2bNlFSEnodq+bNm/P111/HOGd1R30tf6NGjdh7771JSUnxOyvGJBwLOhVYs2YNIkLHjh1JSUnB\nWxa4nC1bttC0aeIum14fy6+q/Prrr6xZs4ZOnTr5nR1jEk5idjYPw7Zt2+jQoQOpqakhA46pn0SE\n1q1bs2NH8ArdxphYsKBTiUQdABbv7EuEMf6xT1VjjPFBRoZ7JBoLOsYYY2LGgo4xxiQgv2paFnTq\nqX/96180adKEJk2a0KhRI5KTk3c+b9GiBQUFBVE798qVK+nXrx/77rsv6enpXHvttRQXF5fbZ8qU\nKXTv3p3GjRuz//7788knn4RM67fffqN///40btyY/fbbj5dffjlq+TbG+M+CTj115ZVXsnXrVrZu\n3cr//d//cfbZZ+98vmnTJho2bFh1IhEaPnw4bdu2Zfny5SxZsoSPP/6YceN2jfX94IMPuPXWW3nh\nhRfYsmULc+bMoXPnziHTuuaaa0hNTWXt2rW89NJLDBs2jK+++ipqeTfG+MuCThxYsmQJhx9+eMzO\nl5uby8UXX0yjRo1IT0/njDPOKBco7r77bu666y6OPfZYkpKS6NChAx06dNgtnW3btvH6669z7733\n0qRJE0488UTOPfdcJk+evNu+ZUaPHs2wYTuXrGfjxo2kpKSwY8cOHnzwQTp06EDTpk054IAD+Oij\nj2q34MaYGrOgEweWLFnCEUccUe3jzj77bFq0aBHycfbZZ1d43PXXX8+UKVPYvn07P/30EzNmzOCM\nM84AoKSkhEWLFrF+/Xq6dOnC3nvvzbXXXkt+fv5u6Sxfvpzk5GS6deu2c9vhhx9eaU0nJyenXFmX\nLFnCAQccwKpVq3jyySf57LPP2LJlC++//z4dO3as9ntiTH1RX3u/2YwE1RF0hdNKSuDSS2H4cNi+\nHfr12/2YgQPdY8MGuPDC3V8fNgwGDIAff4QIFpPbvHkzK1euLPdBvHDhQq6//npSUlLo0KEDkyZN\nCjnly7///e9qnw+gd+/eTJgwgQ4dOlBSUsKVV17JeeedB8DatWspKipi2rRpfPLJJ6SkpPDHP/6R\nf/zjH4wePbpcOlu3bqV58+bltjVv3pwtW7ZUeO6cnBxuvPHGnc/LannJyckUFBSwbNky9txzTws4\nps4rLIT8fMjLg/QEWuPYajr13NKlS2natGm5KV322WcfZs2axZw5c+jYsSNvvfVWrZ2vtLSU008/\nnfPPP5+8vDw2bNjAxo0bufXWWwFIS0sDYMSIEbRv3542bdowcuRI3n333d3SatKkCZs3by63bfPm\nzRVOrVNYWMgPP/zAoYceunPb0qVLOeKII+jSpQtjxozhnnvuoW3btlxyySX8/PPPtVVsY2rV5Mmw\nYAHk5EDnzu55orCaTnVkZ5d7mh8499gee+z2ejlt2lT+eoRLZi9ZsoTDDjus3Cj79u3b7/w9NTW1\nwpkVzjzzzAp7lZ100knMmDFjt+2//fYbP/74I9deey1JSUk0bdqUq666ilGjRvHQQw/RsmVL9t57\n77BG/Xfr1o3i4mK+++47unbtCrggcvDBB4fcf9myZXTo0IE99tgDcPOoZWdnc9lllwFw2WWXcdll\nl7F582aGDh3KrbfeWun9IWP8kJcHQ4dCaal7np/vnvftG9saj181Lavp1HOV3c9ZtWoVM2fO5Jxz\nzgn5+owZM3b2eAt+hAo4AG3atKFTp06MHz+e4uJiNm3axL/+9a9yHRmuuuoqnnjiCdatW8fGjRsZ\nM2ZMyHtEjRs35vzzz+euu+5i27ZtzJ07l7feeovMzMyQ587JyWHdunX88MMP5Ofnc+edd7Jq1So6\nduzIt99+y6xZsygoKKBRo0akpaWRnJxc1dtnTMzl5kJwa3dqqtseK37WtCzo1HNlzUvBNm/eTGZm\nJhMnTqz1KfynT5/Oe++9R+fOnenSpQsNGjTgscce2/n6nXfeydFHH023bt3o3r07PXr04I477gBc\n7eq+++7bue+4cePIz8+nbdu2XHrppYwfP77Cmk5OTg6nn346Z555Jl26dKFdu3Z07tyZ0aNHU1BQ\nwG233UabNm1IT09n3bp15c5jTF3RqRMUFZXfVljotsdCXh4MHaKUlkJJya6aVl5ebM5vzWv13KJF\ni3bbVlxczCWXXMLdd9/NAQccUOvnPOKII8jOzq5waYOUlBTGjRtXbuxOmeAaVKtWrXjzzTfDOm9O\nTg6DBg1i2rRda/WNGDFi5+8LFy4MtwjG+CY9HbKyXP8iEVfLycqKUROXKrm5QgqF5LNrLF9ZTSsW\nebCaThx65ZVXWLBgAffeey8ZGRlMnTrV7yzVipycHLp37+53NoypscxM6NULDj0UVqxwz6ursBB+\n/z2MGkpxMUyf7nrfjh/valqSultasappWU0nDmVmZlZ4X6S+2rhxI+vWrdvZ4cCY+i411T0iqV2U\n3ZMRcfdksrJCBK6NG+HZZ+Gpp2DVKthvP2jSxKtpiT81LaymY+qJli1bUlhYaEtMm4QX2Put0nsy\nF18Mf/2rq8JMnw4//ABXXAHUTk0rUhZ0jDGmHgnZ+y1FyZ38XzjzTFi3zm0cPRqWLIHZs6F/fwjq\nzZmaCs2bx35gqjWvGWNMPRKy99uWHXT664XQoQF89x20bQvHHONPBqtgNR1jjKlHynq/JSUpzfid\nNLaT1eUR0l99wlWDTjjB7yxWymo6lVDVsEbWm/pFVf3OgjHVpwqffAKffkrmrbcyfrxw3Or3uOW5\nA0k//U6/cxc2q+lUICUlJeTMyKb+KyoqokED+75l6omiInjpJTjqKOjdG/75T9i8mdRUWNxlAOmn\nx25Zk9pgQacCbdu25aeffmL79u32zTiOlJaWsnbt2t1mtzYm1rKzK5+OEYD//tfdxLn8cjeTfVYW\nrFwJzZpFP4NRYl/3KtDMu6g///wzRcF37Tw7duygUaNGscxWnVJfy9+4cWPatGnjdzaMCe2772Dr\nVujRA7p2hcMOgwkT4PTToYLJe+sTX4KOiAwHbgHaA18BN6hqyOmOReR84GqgB9AIWAaMVtW3A/YZ\nCLwQ4vA0Vd0RaT6bNWu2M/iEkp2dTY8ePSJNvt5L9PIbU2tU4eOP4bHH4J133OwBs2ZBu3YQYlmQ\n2lBlLStKYh42RWQAMBa4DxdI5gEzRGTfCg7pDcwCzvL2fxd4Q0ROCtpvOy6I7XzUJOAYY0xlam3l\nznfegZ49oU8fmDcPRo2Cl1+uhYTrJj9qOiOBiao6wXs+QkTOAIYBtwfvrKrXB236m4icBZwHfFJ+\nV43RPKnGGFMDGze6NbgaNnT3aHbsgGeecfduvIUQ41VMazoikgr0BGYGvTQTOL4aSTUFNgZtSxOR\nVSKyRkT+LSLW7mOMqVtWrYIbb3SLNk6a5LZdfTV8+SUMHlytgBNWR4Q6KNY1nTZAMrA2aPta4NRw\nEhCRa4C9gcBlh74F/gwsxQWk64G5InK4qn4XIo0hwBCAdu3akR3hldu6dWvEx8aDRC5/Ipcd4qP8\nN9zg1qEaM2ZJtY4rK/umTe747Oyqj2/y/ffsM2UKbWfPRkVYd8op/NigAdvq2XtYK9ddVWP2APYC\nFDgpaPvdwDdhHH8B7t7NuVXslwzkAI9XlWbPnj01UrNnz4742HiQyOVP5LKrxkf5e/d2j+oqK3u1\njj/qKNUmTVRHjlRdvbr6J60jAq87sEgjiAOxrulsAEqA4Cnm2rJ77accEbkAV7u5QgN6roWiqiUi\nsgiwefCNMbFVVARTp8L48fD229C6tWtKa98eWrTwO3e+i+k9HVUtBBYDfYNe6ovrxRaSiFwMvAgM\nVNVpFe0XsL8AhwG/RJ5bY4yphi1b4NFHYf/93VoBmzbBjz+617p3t4Dj8aP32qPAZBFZCMzFjcHZ\nC3gaQEQmAajqFd7zS3A1nJuBOSJSVksqVNXfvH3uBuYD3wHNgOtwQWdYjMpkjEkwhYVuLZu8PEhP\n/c0Fm02b3FQ148e7ZQbiYDBnbYt50FHVqSLSGhiFG0/zJdBPVVd5uwSP17kal88x3qPMx0CG93sL\n4Blcs93vwOfAyaq6MBplMMYktsmTYeH8UlKkiM6dG5KV1YrMW2+FU06ps0sK1BW+zEigquOAcRW8\nllHZ8wqOuRG4sTbyZowxlSn4NJeho46jRBtSog3BW7mz74rbYr4gWn1kdT9jTEIqLITffw+xzHNF\nvv4a+vSh2f89Q0pp+clOUlPdUjamahZ0jDEJZ/JkWLAAcnKgc2f3PKSSEljrdaxt3twN7ryyN0Vp\n5edkLCx0k0GbqlnQMcYklLw81xxWWupiSr7XPFauxlNQAM8+63qdXXKJ27bXXvD99xQMPIOsLCEp\nCZKT3SQCWVlY01qYLOgYYxJKbi6kpJTftrN5bMsWt0ha585uWppmzeDaa90s0LCzN1pmJvTqBYce\nCitWuOcmPLaejjEmoXTq5MZvBtrZPPbss3Dzza4X2sSJcOqpUMGS9amp7mE1nOqxmo4xJqGkp7vm\nsKQkSEkuJa1BIVkDP3XBY9AgmD8fPvoI+vatMOCYyFlNxxiTcDJ7LSep1VPsu+F/dE3OJb3tIOA4\naNrUtZuZqLGajjEmsYwaBQceyAW/TWBthyNJXzEP7rnH71wlDAs6xpj4t2gRbN7sfj/ySLj1Vi7p\ntZInu4yFfStatNhEgwUdY0z8mjvXzYF29NHw9NNu2/nnw/33sym1rb95S1B2T8cYE39mzYJ773VL\na+65JzzwgFuhsxbVs/XX6gwLOsaY+HP//fDtt/DYY268TePGfufIeKx5zRhTv5WWwvTpcOyxsHq1\n2zZxohu1ecMNFnDqGAs6xpj6qbgYXn7ZTQtwwQXw66/w00/utQ4doFGjSg/PzrYmMj9Y85oxpv4p\nKIAePdzMzwcf7ILPxRe7ydBMnWZBxxhTPxQXw+zZbqaAhg3hT39yE3Ked56t0FmP2JUyxtRtxcUw\naZILMKedBl984bbfcYfr/mwBp16xq2WMqZsCg82VV7opat56y93DMfWWNa8ZY+qmLVtgxAjYf38X\nbM45xybgjAMWdIwxdUNxMbz4IrzzDkybBi1bwmefQdeuFmziiDWvGWP8VVzsxtUceCBcdZVbTW3d\nOvdat24WcOKMBR1jjH+WL98VbJo3d81oixdDu3Z+58xEiQUdY0xslZTAd9+53zt2hEMOgbffdjNB\nn3uu1WzinN3TMcbERmkpvPaaW7tm82b4/ntIS4M334wouYwM99NmFahfrKZjjIkuVdds1qMHXHKJ\nmzXgiSeqnKbGxCer6RhjomvOHDdrQNeu5aarsZpKYvKlpiMiw0UkV0R2iMhiETmpkn3PF5GZIrJe\nRLaIyAIROTfEfheIyDIRKfB+9o9uKYwxFcrOhmefdb+ffDK88QYsWwaXXmrzoyW4mAcdERkAjAXu\nA3oA84AZIlLRmrG9gVnAWd7+7wJvBAYqETkOmAq8BBzh/XxNRHpFqxzGmBDmzYM//AH69IGHH3bd\noUVcTaeBNawYf2o6I4GJqjpBVb9W1RHAL8CwUDur6vWq+oCqLlTV71X1b8Bi4LyA3W4AZqvqaC/N\n0UC2t90YE21ffw39+sEJJ8CXX8KYMbB0qQUas5uYBh0RSQV6AjODXpoJHF+NpJoCGwOeHxcizfer\nmaYxprpKStzPoiJYuNAtC71iBVx/vXUUMCHF+mtIGyAZWBu0fS1wajgJiMg1wN7A5IDN6RWkmR5Z\nNo0xlUlbs2bX/ZkXX4TDDoM1a2IaaAoLIT8f8vIg3f7T6w2/6r4a9FxCbNuNiFwAPAxcoqqrIk1T\nRIYAQwDatWtHdoTdZ7Zu3RrxsfEgkcufqGVPXb+ejpMmcfS771KSmsqaCy8kd/bsiAZ0rl/fg8LC\nJKZPz6FVq8JqHTtzZlvmz++OiNKxozJy5Lecdtq6auchEol67aGWyq6qMXsAqUAxcFHQ9qeAj6s4\n9gJgO3BhiNdWA7cEbbsFWFVVnnr27KmRmj17dsTHxoNELn9dKHvv3u4RM2++qdqokWpKiv7Yv7+e\nd1xexOefNEk1KUk1OVk1Lc09D9cvv7hj3AAg90hLc9tjoS5ce78Elh1YpBHEgZje01HVQlwngL5B\nL/XF9WILSUQuBl4EBqrqtBC7fFrdNI0xYdi2DVaudL/36uWa1L79lu+vu46NqZHNj5aXB0OHugkK\nSkpcE9nQoW57OHJzISWl/LbUVLfd1H1+9F57FBgoIoNEpLuIjAX2Ap4GEJFJIjKpbGcRuQTXBfo2\nYI6IpHuPVgFpjgVOEZHbReRAEbkd6AOMiVWhjIkrhYXw1FNuLZvLL3cVivR0eP556NSpRknXNGh0\n6uT6LQRnt4bZMjES86CjqlNxXZlHAUuAE4F+uusezb7eo8zVuHtPY3Bdq8se0wPSnAdcAlwJfAFc\nAQxQ1QVRLYwx8aakxHUMOPBAuPZa9/Phh2t1Es6aBo30dMjKcqtUJye76duysqwzQX3hS0cCVR0H\njKvgtYzKnleS5jQgVNObMSZczz8PQ4a4edLeew9OO63WZ30uCxoDB7qkU1OrHzQyM2H8eNc0N2OG\nBZz6xEZuGZPo5sxxn96nn+6a0lq2hPPPd1WJKKmNoJGa6h4WcOoXm2XamAhlZOyaXt8PhYXw++/h\n34DfzZIlbhaB3r3h3nvdtrQ0uPDCsAJOTc+fmurWbbOgkVgs6BhTD02eDAsWQE4OdO7snodt5UpX\no+nRA+bPh4cegg8+qNb5Z85sG/n5TUKzoGNMPVPTLscsXAivvw633+6mrLnlFlfDqcb5H330gMjP\nbxKaBR1j6plqdznOz3e1mccfd88vughWrCBj3n1knNciovM3aFB+sg8bJ2PCZUHHmHom7C7HJSUw\naRIccADceit8+qnbLgLt29fo/MXF5Xu0+TFOJjvbFoCrjyzoGFPPhDVOZf586NkTrrwS2rWDWbPg\nlVdq7fwjR35b43EyFjQSk3WZNiZCfs5yXGGX49JSF41EYMsWmDLFNafVcvfn005bR3b2QTZOxlSb\nBR1jIlDWe0vE9d7KynKBIJbKjVNZuRJGjYLGjV1mevWC5cujujS0jZMxkbDmNWOqqS713mpa9Bvc\ndJO7b/P669C2rZsnDaoMODUe52NMBCzoGFNNdaX31jG/zuDlhfu7paEvvxy++84N8gxj2poajfMx\npgYs6BhTTb723lKFTZsAWNn4YJY0z4ClS+G552DvvcNKosbjfIypAQs6xlRTbfXeqvY0Op9+Ciec\n4KapUWVHFEWlAAAgAElEQVRdo32585A34JBDqnVeW4/G+Mk6EhgTgZj23lq5Em67DaZOdeNrRo8G\nIu9uXFvr0Vh3ZxMJq+kYE6GYTFg5c6Zb0+btt+Guu1yPtKuuqtFyA7YejfGT1XSMqWuKi2HNGujY\nEY4/HgYPdjMKhHnPJhy2Ho3xS9hBR0RSgfOBM4BjcUtMNwJ+Bb4FPgamquqyKOTTmPin6iLAzTe7\nu/w5OdCkCTzxRFROZ+NsjB+qbF4TkT1E5G7gJ+BFoCewEJgAPAS8AeQD1wA5IvKxiJwQvSwbEx/K\njZPJyXGLqJ11lrvh8uCD0MAaIkz8Ceev+gcgD7gLeFVVf61oRy/YXA68LyI3qWpW7WTTmPhSNk5G\nBDp3LCGr4GEyWy5yY26GDXNVEGPiUDhBZ5iqvhlOYqo6F5grIvcAHWuQL2PqvEh7b7lxMkppqesM\nkF+SzNCU5+g7dyvp3VvWXgaNqYOqbF4LN+AEHbNWVRdEliVj4pgquc/NImXHlnKbU/dIIXeTBRwT\n/6zR2JhYWboUrr+eTh9/Q5GsLPeSX+vRGBNrtTZOR0R6isjztZWeMXHl22/hyCPhyy9JH38PWc+n\n2DgZk5Bqs6bTEbgS+HMtpmlM/VVU5BZTO+kkNwt0VhZccAG0bEkmMP4ZGydjEo/NSGBMNLz3Hhx2\nGPzhD7B6tds2aBC03HXfJiYzGhhTx4QzTqcknAfwagzya0zdtnw5nH02nHmmm1lg+nTYZx+/c2VM\nnRFO81ox8Bkwu4r9ugP9a5wjY+qr336DHj3cjZqHHoLrroOGDf3OlTF1SjhBJwdYq6p3VraTiFxA\nmEFHRIYDtwDtga+AG1T1kwr2bQ/8EzgS6ApMVtWBQfsMBF4IcXiaqu4IJ0/GRKSkBGbNgr59oVUr\neP556N3b2syMqUA493QWA0eFmV6VU9+KyABgLHAf0AOYB8wQkX0rOKQhsAF4AKhs7M92XBDb+bCA\nY6Jq7lw45hg47TQ3vQDAgAEWcIypRDg1nceBuWHs9y4QzkiDkcBEVZ3gPR8hImcAw4Dbg3dW1ZXA\ndQAicmEl6aqq2tqHJvp++YXuo0fDhx+6mZ9fftkFn2qycTImEVUZdFT1K1wTWFX75QOrKtvHm6m6\nJ/BI0EszgeOrOkcV0kRkFZAMLAHuVNXPa5imMeUVF8Oxx7LnL7/AHXfA7bdD48Z+58qYekNUNXYn\nE9kLN1t1b1WdE7D9LuBPqnpAFcf/G9gQ4p7OcUA3YCnQFLge6AccrqrfhUhnCDAEoF27dj2nTJkS\nUXm2bt1KkyZNIjo2HiRS+Zt9+SWbDzoIkpJo9emnbGjdmqRu3fzOlm8S6doHs7K7svfp02exqoZ7\n62UXVa30AfSvap8Qx7QHjg2xfS9AgZOCtt8NfBNGuv/GNc1VtV8yrgPE41Xt27NnT43U7NmzIz42\nHiRE+VevVr3oIlVQnTRp5+aEKHslErn8VnYHWKTVjA2qGlZHgqdEZKmIXC0irSrbUUROEpFngO+B\nw0LssgEoAYLvtLYF1oaRl7CoagmwCNfbzZjqKyiA++5zS0W/8w78/e9w0UV+58qYei+cjgRdgJuB\nvwNPiMjXuGas9UAB0BLojOvh1hyYA/RV1XnBCalqoYgsBvoCrwW81Bd4vQblKEdEBBf0ltZWmibB\n9O/v5qfp3x8efdQtHW2MqbFwOhJsB/4uIveza7nqXpRfrvobXDfoqar6TRVJPgpMFpGFuF5xV3tp\nPQ0gIpO8815RdoCIHOH92gwo9Z4Xqrc0trey6XzgO2+f63BBZ1hV5TNmp5UrYc89XceAv/4Vrr/e\nreZpjKk1YU/4qapFIvIR8JbWYPyLqk4VkdbAKNy9ny+Bfqpa1vMt1Hid4F5o5+B6ynX0nrcAnsE1\n2/3u7X+yqi6MNJ8mgezY4WYQuP9+uOUW15SWkeF3royJS1UGHRFJBu4EbsD1DCsRkXeAv6jqpkhO\nqqrjgHEVvJYRYlulg05V9UbgxkjyYhJXRgYct+Ed7s+/AVasgIsvhsGD/c6WMXEtnJrO1cBdQDZu\nDrbOuOluNgNXRS1nxkTZn3Pv5IrV/4CDDoKPPoJTTvE7S8bEvXCCzmBggqoOLdsgIkOBJ0VkqKoW\nRi13xtS2ggLYvh1atmT2nhezpUFLrlkyAlJS/M6ZMQkhnC7TnSnf0wxgKm4szH61niOTMDIyYnzr\n5KOP3Bo3w4cDkNvkUF7bZ6QFHGNiKJyg0wTXlBZoi/ezae1mx5jwhR208vLgT3+CU091s0IPHBjd\njBljKhRu77UOItI54HlywPZynQlUdUWt5MyY2vDhh3DhhW5d6Lvvhttug0aNACgsdJvz8mxiaGNi\nJdygM62C7W+G2JYcYpsxsVVU5JrNDj3U1XDuvx+67pqgYvJktxqBCHTuDFlZkJnpY36NSRDhBB3r\noWbqj02b3OzPX3wBH38M7drBtPLfmfLyYOhQKC11z/Pz3fO+fa3GY0y0hTMjwb9ikRGTeGq1eUvV\nrWtz002wfj1cc407gdeUFig311WC8vN3bUtNddst6BgTXeF0JDCm1pU1b+XkuOatyZOrn0ZhIfz+\nO+QtXeua0C6/HPbbDz77DB5/PGTAAejUybW+BafVKZwlCI0xNWJBx8RcYPNWScmu5q28aqz7Wi5o\nHdeWySuOh/HjYd48OPLISo9NT3f3cJKSIDkZ0tLcc6vlGBN9Yc+9ZkxtqWnzVl4eDB1UQmmp67OS\nny8MXft3+p4npIfZjSUz08Wo/Hw3mbQFHGNiw2o6JuZq1Ly1bh25V95DSuGWcptTU4Xc3OrlIzUV\nmje3gGNMLFnQMTEXUfOWKkycCN2702nWcxQ1aFzuZbsnY0z9YEHH+CIzE3r1csNoVqwIY4yMKjz7\nLBx0EOlfzCTr+RS7J2NMPWT3dIxvUlPdo8JgUVjoVu0cONDt9NZb0LIlJCWR2d3uyRhTH1nQMXXT\n3LkwZAgsW+ZW8hwxAlq3LrdLlUGrCtnZNc+mMaZ6rHnN1C2bNsGwYXDiibB1K/znPy7gGGPiggUd\nU7fccQc88wyMHAlffQX9+vmdI2NMLbLmNeObnc1bq1e7xdW6dnUzQf/5z9Czp59ZM8ZEidV0jH9K\nSmDsWLdctLewGm3bhh1wsrPtvowx9Y0FHeOPL76A446DG26Ak0+GCRP8zpExJgasec3E3gcfuHs1\nrVrBlClw8cVuYRtjTNyzoGMikpEBmzYdwZIl1Tho+3bYYw/XM+3GG+HWW3frBm2MiW/WvGaib9s2\nF2QOP9z9npYGDz1kAceYBGRBx0TXRx+5uW7GjHFLc6r6nSNjjI8s6JjoyM+HwYPd4moNGrilo8eN\ngyZN/M6ZMcZHvgQdERkuIrkiskNEFovISZXs215EXhaRb0SkREQmVrDfBSKyTEQKvJ/9o1YAQ2Eh\nbNuWXPHCaw0bwvffw1//CkuXuh5qxpiEF/OgIyIDgLHAfUAPYB4wQ0T2reCQhsAG4AFgQQVpHgdM\nBV4CjvB+viYivWo39wZ2rdq5YkXj8ktNr1sHgwa5VdaSklwvtQcfdPdwjDEGf2o6I4GJqjpBVb9W\n1RHAL8CwUDur6kpVvU5VJwK/VZDmDcBsVR3tpTkayPa2m1oUuNR0aWmSt9S0kvfU626Q56RJbrJO\ncM1qxhgTIKZBR0RSgZ7AzKCXZgLH1yDp40Kk+X4N0zQhlC01HSi1aDu51z4CXbrA55/DBRf4kzlj\nTJ0X66+ibYBkYG3Q9rXAqTVIN72CNENOei8iQ4AhAO3atSM7wrlUtm7dGvGx9dVvv6VSUNALdxmd\nwmKBgRlkX34qrF+fEHPTJOK1D5TI5beyZ9coDb/aP4L7zUqIbVFLU1WfAZ4BOOqoozQjIyOiE2Zn\nZxPpsfXZhPvWc9XNrVGBhqlC1j+2ctxN9/udrZhK1GtfJpHLb2XPqFEasb6nswEoYfcaSFt2r6lU\nR14U0jTBVCEri8y7O/OfpgPo3HkbK3KFzJva+p0zY0w9EdOgo6qFwGKgb9BLfXG92CL1aRTSNIFW\nr4bTT4err4ZevXi++yM0blxiy0QbY6rFj+a1R4HJIrIQmAtcDewFPA0gIpMAVPWKsgNE5Ajv12ZA\nqfe8UFWXedvHAnNE5HbgDaA/0Ac4MfrFSQALFrjZBEpLYfx4GDqUtX0EdmzyO2fGmHom5kFHVaeK\nSGtgFNAe+BLop6qrvF1Cjdf5POj5OcAqoKOX5jwRuQT4B/A34AdggKqGHNdjwlRa6sbbHHYYXHQR\njBoFnTr5nStjTD3mS0cCVR0HjKvgtYwQ26qc915VpwHTapy5BFF2LzBkRxRVeOEFePJJmDPHTV3z\n3HPldnELqC0BMqKaT2NMfLG510x5a9bAWWfBX/4CTZvC5s1+58gYE0cs6BhHFSZOhEMOcZNzPv44\nzJ4Ne+3ld86MMXHE5ilJUIWFbiLovDxcD7SyJrXDDnM/99/f7ywaY+KQBZ0EVDZhp4jSeb8Ssh7Z\nSuaIFvDGG9Cihes8YIwxUWCfLgkmcMLOkhIhv7ABQ0fu4ZYoaNXKAo4xJqrsEybB5OZCihSW25a6\nRwq5uT5lyBiTUCzoJJhOH0+kaHtxuW2FRWLDb4wxMWFBJ1EUFACQPvgcsi76iKQkJTnZra+WlYVN\nZ2OMiQkLOvEuPx+uv96NBi0uhtatyXz1HHr1Eg49FFasgMxMvzNpjEkUFnTi2WefwZFHujE3xxzj\ngo4nNRWaN7cajjEmtizoxKOiIvjb3+C442DrVvjgAxg7Fho18jtnxpgEZ0GnnsrI2DV/2m6Ki2HK\nFLj0UsjJgVNrsiirMcbUHhscGi9KS91MAgMGuAk6P/3UDfSsQIKutmuM8ZnVdOLBjz/CaafBoEFu\n/jSoNOAYY4xfLOjUU4WF8PvvSt6T0+DQQ2H+fHjmGbjmGr+zZowxFbLmtXqobO60hlpA5xH9yOp6\nE5kzLrNJOo0xdZ7VdOoZN3eaUloK+dqIfPZg6JpR5DW2gGOMqfss6NQnBQXkjnyClKLt5TanporN\nnWaMqRcs6NQXy5ZBr150emU0RZpS7qXCQmzuNGNMvWBBp65ThXHjoGdP+Pln0t+eQNYLqSQlYXOn\nGWPqHetI4JOygZ1VjpfZtAnuvdcd8MILkJ5OJjB+vJtWbcYMCzjGmPrDgk5dNWcOHH88tGzpukPv\nuy+I7Hw5NdU9LOAYY+oTa16ra/LzYcQI6N0bnn7abdtvv3IBxxhj6iur6fiksNDFl7y8gNrK0qVw\n2WWu08CNN7oZBipg09gYY+ojCzo+KBvcKQKdO7uOAJk6CQYPhlat4P333bQ2xhgTZ6x5Lcbc4E43\nP2dJiavtDB0KeXseCuec42aFtoBjjIlTvgQdERkuIrkiskNEFovISVXs39vbb4eIrBCRq4Nev0dE\nNOiRF91SRCY3F1LKD7MhNRVyW/SAadOgTRt/MmaMMTEQ86AjIgOAscB9QA9gHjBDRPatYP9OwLve\nfj2A+4EnROSCoF2/BdoHPA6NSgFqqFMnKCrSctsKC9UGdxpjEoIfNZ2RwERVnaCqX6vqCOAXYFgF\n+18N/KyqI7z9JwD/Am4O2q9YVfMCHuujV4TIpf/6FVmtbieN7aRJPmlpSlaWWNdnY0xCiGnQEZFU\noCcwM+ilmcDxFRx2XIj93weOEpHAhqrOIvKT12w3RUQ610qma9P27ZCRQWbRC1x54EIOODyNFSuE\nzEy/M2aMMbER65pOGyAZWBu0fS1Q0Xf99Ar2b+ClB7AAGAicCQz2jpknIq1rnuVasHWrm85mjz3g\npZdg6VK+bpdB8+Y2uNMYk1hEVaveq7ZOJrIX8BNwsqp+ErD9buBSVT0wxDHLgcmqem/Att5ANtBe\nVXfrMCAiTYAVwAOq+miI14cAQwDatWvXc8qUKRGVZ+vWrTRp0qTSfZp99RUH3XsvKzMzyTvrrIjO\nU1eFU/54lchlh8Quv5Xdlb1Pnz6LVfWoaieiqjF7AKlAMXBR0PangI8rOGYO8FTQtouAIiClknPN\nBsZXlaeePXtqpGbPnl3xi8XFqqNHqyYnq3bsqDp/fsTnqasqLX+cS+SyqyZ2+a3sDrBII4gDMW1e\nU9VCYDHQN+ilvrjeaaF8CpwaYv9FqloU6gARaQQciOugEHu//AKnnw533AEXXghLlkCvXr5kxRhj\n6hI/eq89CgwUkUEi0l1ExgJ7AU8DiMgkEZkUsP/TwN4iMsbbfxDu/s0jZTuIyCPeWJ5OItILmAY0\nxvVyi73Fi+HTT+HZZ+GVV6B5c1+yYYwxdU3Mp8FR1aneDf5RuPE0XwL9VHWVt8u+Qfvnikg/4DFc\nt+qfgetU9fWA3fYGXsF1LFgPzAeODUgz+goLYe5c6NMHzj7bjQJt2zZmpzfGmPrAl7nXVHUcMK6C\n1zJCbPsYOLKS9C6ptcxF4vvv4dJLXTPa99+7WaEt4BhjzG5s7rWaeukl6NEDfvgBXn3VBRxjjDEh\n2SzTkVLlgIcfhnffhRNPdMFn35Az+RhjjPFYTSdSIuS3bw933QWzZ1vAMcaYMFhNpwZWX345nTMy\n/M6GMcbUG1bTMcYYEzMWdIwxxsSMBR1jjDExY/d0IpSRAZs2HcGSJX7nxBhj6g+r6USosBC2bUsm\nr04uim2MMXWTBZ0ITJ4MCxbAihWN6dzZPTfGGFM1CzrVlJcHQ4dCaSmUliaRn++eW43HGGOqZkGn\nmnJzISWl/LbUVLfdGGNM5SzoVFOnTlAUtIpPYaHbbowxpnIWdKopPR2ysiApCZKSSklLc8/T0/3O\nmTHG1H0WdCKQmekWAu3ceRsrVrjnxhhjqmbjdCI0bx5kZy8mPT3D76wYY0y9YTUdY4wxMWNBxxhj\nTMxY0DHGGBMzFnSMMcbEjAUdY4wxMWNBxxhjTMxY0DHGGBMzFnSMMcbEjKiq33nwlYisB1ZFeHgb\nYEMtZqe+SeTyJ3LZIbHLb2V39lPVPaubQMIHnZoQkUWqepTf+fBLIpc/kcsOiV1+K3vNym7Na8YY\nY2LGgo4xxpiYsaBTM8/4nQGfJXL5E7nskNjlt7LXgN3TMcYYEzNW0zHGGBMzFnSMMcbEjAUdY4wx\nMWNBxxhjqiAiEvjTRM6CTgREpKuItPM7H36xf8DElMjXXb0eVxrQ8yqR3ofavPbWey1MItIWyARu\nBNYDxcAvwDTgdVXd5mP2fFX2h6hx/sckIgcBBwHNgW3AAlXN9TdX/kmg634w0B133bcD8xP5ukPN\nrr0FnTCJyETcB86/gV+B1sARuD/GNcBDqvqBbxmMARFJAv4I7AnsAfwEfKyq63zNWAyIyG3An4Cu\nuHL/CpQCnwMvA3Nx/4Nx9w9l1z0xrztE59pb0AmDF9W3AP1UdU7Atn2AXsBgYD9ggKou8S2jUSQi\nTYHngD64f7o1gAL5wMfAi6r6jYhIvP0DikhrYCVwi6o+LSL7AMcAxwE9gUbA7aqa7Vsmo8Sue2Je\nd4jetW8QjczGoYOAXKCwbIP3Jq8GVovIW8A8YAAQl0EHuA44ABd4PxORA4GjgBOB04HDROQvqrre\nz0xGyUXAN6r6NICq/gj8CLwuIocDdwJvi8gRqrrCx3xGg133xLzuEK1rr6r2qOIBpAEfAZ/iqtlJ\nIfYZASzxO69RfA8+AUaG2J4MnAx8B7zndz6jVPaLcF86Tg4oc3LA642A+cBwv/Nq192ue12/9tZ7\nLQyqmg/cgQs+k4ArRGQfEWkMICJ7AL2BL/3LZfSISANc2S4QkT29bckikqyqJeqaHK8G9va+Acab\n/+CaWUaKyKFemUvKXlTVHbiOJa19yl9U2HVPzOsO0b32FnTCpKrzgctxTWrjcTcSp4jI88A3uPs7\nD/qXw+hR1WLgX0A6cLOItAv+BwSWAx2Js8WtvPbq7cA9QDfgMxGZLiLnikgnEekpIiOAg4HJfua1\ntgVc972AWxLpunvygb/jmpgS5rpDdP/nrSNBBLzu02cB5wE7cN8IXlPVb3zNWJR4PViSgKuA+3D3\nAqcBU3Ft3IcB5wDdVfVov/IZCyJyGfBn4HjczdW13s8nVXWsn3mLBhFJAS4FHgFS2XXdVxPH111E\nmqvq7wHPLweGAD1wf/8/E8fXHXZe+4Hs+p+fDkyhhtfegk4NiUiSqpb6nY9YEZEWuD/Ey3BdxrcA\nBcBC4H5VXeBf7mqf18xQArRQ1Y1eAG6IG7NxENAK+ERV1/qYzagQkSa4+xa/As1wwfZS3AdOAW7M\nygLi7LqLyNG4Gs5HuL/rRV5tt2ysVkugA67rcDxe932AfFXd4D1vgbv2/YGjcV+0txPh/7wFHVMp\nEWkGbNGAPxTvg7cR0AQ4BNgWTx86ZbxBgTcDpwCLgL+p6hf+5io2ROQPwO243kpzgUGq+ouItMQF\n3Q5Agzi97vcBtwHZQAqu+fx9oAUwRlWb+Je76BORWcBSVb3Rey64//dOwG/eT1HVeRGlb0HHVEZE\nsnDfaBYCq1R1c4h9Wnq1gLgaqyEin+H+yWbimlK74XoyfRuwT1NV3eJTFqPC+5BZDrwH/Bd3r3I0\n7hv+EbimlvtV9XPfMhlFInIC7j7NP3GB5jTcwMgOuJr9HcBijcNZCbxrvwM4VlU/9754PYDrtfsj\nbkjI31R1a8TniKPPCFPLRORS4CVgM+7D9wPcN74vgJ9UNd9rgnkRuFNVc3zLbC0TkStxtZyTVHWT\n9884E1fugWUBVkTGAo+r6g++ZrgWichAXNmP9q7xmcALuJ5cObjg2wo4Q1V/8iuf0SQiQ4CTgCtw\nNbu+uHsa3+P+H3YAf46n6w4gIoNxg2G7iUgX3D2cfOB1XIeKP+I6UQ2INPBY7zVTmVNwy9MeCYzD\n3Tx/EXgNGCUip+Dmo+sXTwHHcz7wHy/gpHo1uPuAE0SkqxdwegMj4u2DBzfI+U1vqAC4Efhrgf6q\nOhg3Jm0PIB67SZc1H7+ACzY3el2jG+DmWjwb9z/xXRxed3CdJeZ4v1+Cm4XgElUdo6rDcEG4F66J\nLSIWdExI3g30XGCTqq5Q1UdU9VDcjcSPgSuBV4EniLMuoyLSECgCfvdqNIUi0kBVZ+Pek6u9XYfg\nAnDcEJFGuFrt4oDNfYEs756OAF8Dy3DdheOOqpaqahGQBQwXkXRgODBdVX9Q1edUdZC/uax9IpKG\niwl/EJH/ALfgJjP+yRujI7i/i69xX0QiO481r5mKeDeN26mbXykVKArqUDAAeAU4UuNozjnvn6sH\n0EdV/xl4r0pEzsLV9nrg2rfPUtW5/uW2dnll3xtooqpfe8/3AdaqaoG3TxPgB1zZF/mX2+gTkeG4\nmeX3B45R1UVlAyR9zlqt8651J1yz4hm48Vl/V9WPAvZpgpuJ4GxVXRwyoSrY3GumQqq6Edjo/V4I\nO5sexPunawbsiKeAAzvn1fuf9wg2E9ebawawOZ4CDuws+49Bz1d7H0hl1/8C3HWP64DjeQ53L6MR\n8BVAPAYc2HmtVwArROQV3MDPsibWsmt/EVAcacABCzqmmoLGJDUF7vYrL7ESUMsRVS0SkZdwHSzu\n8TVjMRRQwz0P17z4mI/ZiRlVLRCRW3A1v/wqD4gT3pfM5UGbz8dNAlqjwbDWvGYi5o1YLkmkwbGw\nsxniKGCFqv7qd35iySv7vsD6sgGTJjF4174jsE5rsGilBR1jjDExY73XjDHGxIwFHWOMMTFjQccY\nY0zMWNAxxhgTMxZ0jDHGxIwFHWOCiMh5IjIyxPZ7RKROdPcUkYkiot4jOwrpjwpIf01tp28SlwUd\nY3Z3HrBb0AGepQZzTkVBHi4/w6OQ9gte2u9GIW2TwGxGAmPCpKprcLPu1hUFqjo/Ggl7Sxb8JCLr\no5G+SVxW0zEmgIhMxM2g3SGgeWml91q55rWy5yJyoIi8LyLbRGS1iFzlvZ4pIt+IyFYRmS0i+4c4\n3+Ei8raIbBSRfBGZKyIn1SD/SSKyRUTuCtre0svrld7zbiLyhoisE5EdXr5f82YXNyZq7A/MmPLu\nBfbELeFwrretoIpjXgMmAI/gmrqeF5GuQAZu2eMU3HxVL+PWIgFARI4EPsEtijUYt+781cCHInJ8\nhJMqdsMtIx68qmcP72fZ9n8Dm4BhwAbcqpj9sC+iJsos6BgTQFV/8JqUCqvRdPWwqk4CEJFFwDnA\nUKBT2fLeItIeGCsi+6nqqrLjgNXAKQGzeL8PfAncibu3VF1Hej+DZ8jugQueX4tIG9zyw39U1bcD\n9nk5gvMZUy32rcaYmptR9ou3HMQ6YH5ZwPF84/3cB3YumNUbV0sqFZEGXtOWAB8CJ0eYl564CRmD\nl5E+EvjKW5zsV9wU9g+IyGCvVmZMTFjQMabmNgY9L6xgG7h1WQBaAcm4Gk1R0ONaoKW3fkl1HUno\ndYB64DWtecsU9AUWAfcDy0VkhYgMi+B8xlSLNa8Z449NQCnwFDAp1A7VXTLCm3r+CGB80Pa2uIXI\nngpIewVwhXfM4bhAN05EVqrqDIyJEgs6xuyuAEiL5glUdZuIfIL7wP9fLa1JtD/QAghe2XIErlVj\ntxVevVrPEm8w7F+AQwhoLjSmtlnQMWZ3y4BWXnPTItzSzDlROM9IYA7wvog8B/wCtME1kSWr6m3V\nTK+sE8EgEfkRd2/pNFwXcICjROR/uE4EY4GpwPe4Zr6BQDEwK+LSGBMGCzrG7O5Z4FjgPlzNYRVu\nxcRapar/E5GjcUt+Pw40B9bj7sk8HUGSRwK/4bppP4DrOv0mbl37V4ABqjpWRPJwveZGAnsDO4Ac\n4OwIu2kbEzZbOdSYesgbxJoBdMG1kpWIyAe4J31rIX3B1YCeA/6gqnvXNE1jwHqvGVOf7Yfr7faR\n97wHUFs1lTu8tK+opfSMAaymY0y9JCIdcfd/ALbgmshWAher6mu1kH573CwF4AbKflHTNI0BCzrG\nGGNiyJrXjDHGxIwFHWOMMTFjQccYY0zMWNAxxhgTMxZ0jDHGxIwFHWOMMTFjQccYY0zMWNAxxhgT\nM3PyZOgAAAAGSURBVP8PmtkQbX8GJRYAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x11984d630>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a: -0.54 ± 0.22\n",
-      "T2: 86.06 µs ± 47.48 µs\n",
-      "c: 0.58 ± 0.23\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# arrange the data from the run\n",
     "\n",
@@ -555,7 +403,7 @@
     "    data[ii]=float(result.get_counts(key)[keys_0_1[1]])/shots\n",
     "    sigma_data[ii] = np.sqrt(data[ii]*(1-data[ii]))/np.sqrt(shots)\n",
     "    \n",
-    "fitT2e, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([-1,10,0], [0, 150, 1])) \n",
+    "fitT2e, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([-1,10,0], [1, 150, 1])) \n",
     "ferr = np.sqrt(np.diag(fcov))\n",
     "\n",
     "plot_coherence(xvals, data, sigma_data, fitT2e, exp_fit_fun, punit, '$T_{2echo}$ ', qubit)\n",
@@ -567,44 +415,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The last calibration of $T_2$ was measured to be"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'54.3 µs'"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "str(params['T2']['value']) +' ' + params['T2']['unit']"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## CPMG measurement\n",
     " \n",
@@ -613,11 +442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -656,23 +483,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running on backend: ibmqx4\n",
-      "status = RUNNING (20 seconds)\n",
-      "status = RUNNING (40 seconds)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run the program on hardware/simulator\n",
     "result=Q_program.execute(circuits, backend=backend, shots=shots, wait=20, timeout=600)"
@@ -680,33 +495,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAAExCAYAAACu6t9NAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd4lFX2wPHvIST0IlKCrApKWQsKogIKgigrFkRRF1yN\noFIERRF1V9RdUH8qNhYsKLK6COKKApZVWVhZgkpTkBILKFLEAlKFQAok5/fHfRMmk0kySaZkJufz\nPPOE986dd+6dYebMra+oKsYYY0w4VIl2AYwxxsQvCzLGGGPCxoKMMcaYsLEgY4wxJmwsyBhjjAkb\nCzLGGGPCxoKMMcaYsLEgY4wxfkSkhYi8IyI7RERFZGq0yxSrqka7ACY4IlIb+I3gfxg0UNU9YSyS\nMSEnIu2AK4Cpqro5ikWZCpwGPAJsA74v6QEiUhe4A7gSaAUkAJuB94GnVPXXMJW1QhNb8R8bRKQ+\ncJlf8jDgHOBuYLtPepaqvhWpshkTKiIyEPgncL6qpkapDNWADOA5Vb09yMe0BuYBxwNzgIXAIaAT\ncD3uB+Jlqro8LIWuwKwlEyNUdS/wmm+aiNwJZAITVfVwVApmokJEEoBqqnow2mWJQ00AAXYHk1lE\nagL/BpoBvVX1A5+7XxKRScBHwHsi0raytWhsTCZGiUgicAqwtrIFGBEZ6PWTXyAifxORLSKSISLL\nRaSTl6ebiHwqIgdE5BcR+WuA81QTkftE5CsRyRSRvSLybxFp75evjoj8n3f+nSKSJSIbRGSc9wXj\nm7e6iIwVkfUictA7Z5qIPOmXb6xXh+YByrVZRFID1PdCEfmriHyP+3Hxx9LUI0qvXd7z9RCRu0Xk\ne+/1+1ZEBvi/JrhWDMBC73H54yHBvrZFEZGGIvK8iGwVkWzv7/MicrRPnqnAFu9wjE8Zuhdz6puB\n1sDf/QIMAKq6ArgPaAzcE0xZ44m1ZGLXKUA1YFW0CxJF43D93hOBJOAuYJ735fUy8BIwA/dl/JCI\nbFLV1yA/SP8H1904HXgOqAcMBhaLyHnelwO4X6iDgNnA68BhoBvwZ6A9cJFPmZ4HbgKmAX/3ytcK\n6BGC+j4FJAJTgH3A+lLWw1ekXrs8jwI1gMlAFq6rd6qIbFDVxV6eOUBTYIiX/xsvPW88pMyvrYjU\nA5YALYFXgC9w790woIeInK2q+73yrfbO/7ZXJnzKEsjV3t8pxeSZCkwArqKyBRpVtVsM3oAbAQWG\nRLssUaj7QK/uXwBJPumXe+mHgbN80pOAX4ClPml3enkv8jt3XeAHINXv8YkByvGwd46zfdJ2Ax8G\nUYex3mObB7hvs9/z59V3PVDTL2/Q9YjSa5f3fKv8nq8ZLtj8q4jydQ/wugT12hbxej/inXe4X/qt\nXvrDPmnNvbSxQZ57F7AviHxp3nlrR/szFMmbdZfFrjO8v5W5JfOCqmb7HH/i/V2mqp/nJXp5PsP9\n6s1zPbAOWOl1ozQUkYa4L9X/Al1EpEbe41X1EICIVBWRo7y8H3nn6uhz3t+AU0Tk1NBVM98LWngM\nJuh6BDhX2F87H5N8n09VfwK+9TtvScrz2l4J7MC10HxNBnZ695dVXa9sJcnLU6cczxVzrLssdrXH\n/epM800UNzPmOeACoBHuV+izqvpsxEsYfht9D1R1j4gAbAqQdw9wtM/xSbjumx3FnL8hsBVARIYD\nt+C6Kf1/nB3l8++RuC6kNBHZiJtl9G/g36qaW0J9SvJtgLRS1cNHxF67QM/n2YWbjRWs8ry2LYAV\n6jd+qaqHRWQ9R360lcU+XKApSV0gFxfUEDchoDeuq3E/8BbwZ7/gH/MsyMQgEakCnA58o6qZfndX\nxc3r/wPug30arq99u6q+GdmShl1OKdN9CS5Ajyomzw4AERkFPA3MB54BfgaycV0+U/EJOqr6rjeY\nfwlu3OZC3MDwJyJyoc8XSHFrB4r6XAaaSRZ0PfxE5LUL4rwSxPMBpXptI+1L4DwRaamqGwJl8CaI\ntAG25LWKcT8G71HVAyLSCHgTN0FgbATKHDEWZGJTK6A2rl+9AFU9APjOBlotIh8CXXD/ifOJyB+A\nB3C/znNxA6vLgBeBD3Af5qOAV1R1lPeY3sDjuEHhYUAt4F5gOe4LuD2wAjeVM93nuYbiBpeb4AZe\nTwQWqOrEcrwO5fEdrqX3vyB+Bafgxkku9s0rIr0CZVbV3bjp5q+Jax6Mw00S6IP7tQpHpsc28M6d\nd87quMHvgF9W5axHqITzOYtduBfkaxvIRqCNiFT1bc2ISFXczLBALa1gzQbOw00OubeIPDfguhPz\nlyGo6td+eXIpXfdhTLAxmdgU9HiMNxOoC7DWL/0G4FXcgGgyLtB8hGshHYfrNjkF6AkMF5HzfJ67\nBW6aZ3Pch+pxYDTQHzgW1wXS1+e57sB1dVyF63apBvQC1pSm0iE2DVfvgL/GRaSJz2EO7stPfO6v\nit8XiogkiFs0m0/diG/e+9TA5668rq8L/Z76Tkr3uSxNPUIlnM+Z98PE97Uq7WsbyDu4wDjIL32w\nl/52mUrr/AP3ft4Z6IeHiJwBPIbrun7e7757RSQd+BX32ZtQjnJUSNaSiU15axEKtWQCeA7Yi/ti\nAPK3v3gGuE5V53nJvwK/emMPb6nqU1765yKyCtcP/zEuyLysR6azrsH1zw9X1V1e2la8/1vecz0E\nXKKqaV7aVFwraHXpqx4yE3EB9EkR6QH8D9e3fhxuPCsTON/LOwv3JTFXRObg+tb/hFvR7asO8IuI\nvIf78vsVF5CH4cY1/u2T9yPc4PlD3jqNTbgfA53w+uzDUI9QCedzfo77RX+/iBwFHMC9NusJ/rUN\n5AngGuB570t/Fe5zdLN37ifKWF5U9aCIXI6b1v2BiMwGUnFjpmfjWsJ7gMtVdbvfY8cB40TkJOA6\nXCCKL9Ge3ma30t9wM3hygbol5BuPa8E09Eu/AthUxGO+Aq70S9uYl4abonqRz31DgYV++XcBnbx/\n9wF+8bv/YmBzOeo/kKKnuSpu3yv/9Kl4P3590qoCt+O+2A54t+9wXYF/8MmXgGupbcBNu92C+1I6\nCZ+prrjukMdws7F2eXk347oHWwUoU2vcF9NB3A+BN3HjPJsJPA24UH1LU48ovXbFPV9qoP8HwADg\na9y4l3rPX6rXtojXqREwCfgR9wPhR1zLwv/z0dz3fS3F/8u6uK7qVbgWmXq3L4H6QTz+Gvw+S/Fw\ns73L4pSITMD9quyhqjv87rsZuFVVz/BLr477cHRV1aVe2tm4X93H4hYC7gAaqWreDJkXgf2qeo93\n3Bz3ZVxHVTNEZBAwTFU7+DzPFO8cV4S84sZUEF6X6lu4H3V3qer4EvL/CXhSVZtFonyRYmMycUhE\nnsH19RcKMJ4vcOsNzheniTfmkrf+4DpvPcipuHGbB1X1N1xX2Za8AOM5A1jpd/yNqmZ4x18Cp4rI\n2eK2IhmK+6Uaza4yY8JO3QSDfsCHwNMiMizvPhGpJ27LnfreZ7AtbhLOvCJOF7NsTCbOiMjxwAhc\nd8Imb+0DwCeqejGAqq4SkdtxA5bJuDGAh7x8HwLVcX3I24HxqjrJu689PgHF+6XWloJBpj0+Y0Wq\nukxExuM+PBm4MaLvcd0exsQ1ddOqLw10F25R63hcV+CvuC1sxkSudJFh3WUmn9cC2q+q94fxOU7B\nBZijtfAaH2NMnLHuMuPrdFz3VsiISEcRaeV1CZwOvIHbJ8oCjDGVgHWXGV+nEeIgg+tOexSoiZuZ\n9gJ+awWMMfHLusuMMcaETaVvyTRs2FCbN29epsceOHCAWrVqhbZAFUS81s3qFVvitV4Q+3VbuXLl\nTlVtVFK+Sh9kmjdvzooVga7pVLLU1FS6d+8e2gJVEPFaN6tXbInXekHs101EtpScywb+jTHGhJEF\nGWOMMWFjQcYYY0zYWJAxxhgTNpV+4L8oubm57Ny5k71795KTE/iifvXq1eObb76JcMkiI17rFu56\nVa9end/97nckJiaG7TmMiSUWZIrw448/IiI0b96cxMREfPYAy7d//37q1KkThdKFX7zWLZz1UlV2\n7drFjz/+SIsWLcLyHMbEGusuK8KBAwdo1qwZSUlJAQOMMf5EhKOPPprMTNsxx5g8FmSKUaWKvTym\ndOwHiTEF2beoMcZUQt27u1u4WZAxxhgTNhZkjDHGhI0FmRj16quvUrt2bWrXrk316tVJSEjIP65f\nvz5ZWVnRLmKZde/enerVq+fXp02bNvn35aXl3RISEhgxYkSR59q9ezdXXnkltWrV4vjjj+fNN9+M\nRBWMMR4LMjFqwIABpKenk56ezn333cdll12Wf7x3716qVasW7SKWy3PPPZdfn/Xr1+en56Wlp6ez\nfft2atSowTXXXFPkeW699VaSkpLYvn07M2bMYNSoUXz11VeRqIIxhigFGREZLiKbRCRTRFaKSNdi\n8nYTkSUisktEMkRknYjcHSDfVSLytYhkeX+vDG8tKo7Vq1dz+umnR7sYETdr1iwaN25M166B//sc\nOHCA2bNn8/DDD1O7dm26dOnCxRdfzPTp0wPmf+SRRxg2bFj+8Z49e0hMTMyfkvz444/TrFkz6tSp\nQ5s2bViwYEHoK2VMnIl4kBGRfsBE3NUS2wNLgLkiclwRD0kHngHOA04G/g94UESG+5yzMzATmAG0\n8/6+JSIdw1WPimT16tW0a9cu2sUo5LLLLqN+/foBb5dddlmxjx09ejQNGzbk3HPPJTU1NWCeV199\nlRtuuKHIacPffvstCQkJtG7dOj+tbdu2RbZk0tLSCryOq1evpk2bNlSvXp3169fz3HPP8fnnn7N/\n/37mzZtHWa9DZExZRWpGWChFY8X/KGCqqk7xjkeISC9gGDDaP7OqrgRW+iRtEpG+QFdgkpc2Elio\nqo94x4+IyPle+rUhK7nfu1sjJweuvRaGD4eDB+GSSwo/ZuBAd9u5E66+uvD9w4ZBv36wdSsce2yp\ni7Rv3z42b95c4Mvxs88+44477iAxMZFmzZoxbdq0qGxz8v7775fpcY8//jgnn3wySUlJvPHGG/Tu\n3ZvVq1dz4okn5uf54YcfWLRoES+//HKR50lPT6devXoF0urWrcv+/fsD5k9LS+POO+/MP/ZtISYk\nJJCVlcXXX39No0aNLMCYmJedDRkZsG0bJCeH73ki2pIRkSSgAzDf7675wDlBnqO9l3eRT3LnAOec\nF+w5Y9maNWuoU6dOgW1Mjj32WP73v//x8ccf07x5c959990olrD0OnbsSJ06dahWrRoDBgzg3HPP\n5cMPPyyQZ9q0aXTp0qXY7Vtq167Nvn37CqQVta1MdnY233//PW3bts1PW7NmTX7wbtmyJRMmTGDs\n2LE0btyY/v378/PPP5enmsZEzfTpsHw5pKXBCSe443CJdEumIZAAbPdL3w5cWNwDReRHoBGuzA+q\n6os+dycXcc6A8VlEhgBDAJo0aRKwO6ZevXqFf/H++98FDnNyckhISIC8fH7359u/H6pVK/7++vWP\nnKcUli1bximnnEJ6enp+Wu3atTl8+DD79+9HVcnKymL//v3Mnj2bKVOmcPjwYW677TauuOIKOnfu\nzHHHHcdPP/3E1VdfzciRI+nWrRudOnViwYIF3HXXXSxfvpzU1FTGjRtHr169eOmll3jrrbdo0aIF\nW7duZe7cuQHL1rdvX5YuXRrwvs6dOzNnzpyg6piTk0NGRkaB92Pq1KmMGjWqyFYJQNOmTTl8+DCr\nVq2iZcuWAKxdu5ZWrVoVetzatWtp2rQpOTk5+a/bwoULueKKK/Lz9u7dm969e7Nv3z7uuOMORo0a\nxZQpUwo9b2ZmZpFdfOGSnp4e8eeMhHitF5Stbnv3uh89qamry/y8u3cnMXhwR3JzEwDXmhk8OIda\ntZbToEF2mc9bJFWN2A04BlCgq1/6GGBdCY9tAbQFBgO7gRSf+7J9j720AUBmSWXq0KGDBvL1118H\nTPe1b9++EvOE20033aS33XZbwPs2b96snTp10uzsbF21apX26tVLs7OzVVU1Oztb9+zZo82aNdMd\nO3ZoVlaWnn766bpjxw5t2bKl/vzzz/r555/rqaeeqgcOHNBPPvlER44cqWvXrtVrrrlGc3Nz9ZNP\nPtELL7wwpPXZs2eP/uc//9GMjAw9dOiQvvbaa1qzZk1dt25dfp7FixdrzZo1g3r9+/Xrp/3799f0\n9HT99NNPtW7duvrll18Wyjdt2jStXbu2btiwQQ8ePKj333+/Arp+/XpVVV23bp0uWLBAMzMzNSsr\nS2+88UYdMGBAwOcM5v9OqC1cuDDizxkJ8Vov1bLVrVs3dyuPJUtU69ZVhSO3evVcemkAKzSI7/1I\nD/zvBHIo3MJoTOGWSAGquklV09SN5YwHxvrcva0s54wHvl06vvbt20dKSgpTp04lMTGR999/n1Gj\nRuWPzSQmJpKWlkb//v1p2LAhSUlJHH300axdu5Z+/fpRu3Ztdu/eTb9+/ahZsya7d++mefPmvP32\n2wwZMgQRoWrVqgW6l0Lh0KFDPPDAAzRq1IiGDRvy7LPP8s477xRYK/Pqq6/St2/fgN1eF198MY8+\n+mj+8aRJk8jIyKBx48Zce+21jB8/nlNOOaXQ49LS0rjooou4+OKLadmyJU2aNOGEE07gkUfcMF9W\nVhb33nsvDRs2JDk5mV9//bXA8xgTK1q0gEOHCqZlZ7v0cIhod5mqZovISqAn8JbPXT2B2aU4VRXA\ndyHIUu8cT/qdc0kZixozVqxYUSjt8OHD9O/fnzFjxuR/Oe/Zs4fc3Nz8+6tWrUpaWlr+os3XX3+d\nHj16sHbtWtq3bw+4AOb77y5duvDee+/lbxz64osv0q1bt5DWp1GjRnz++efF5pk8eXKR9/l33TVo\n0IB33nkn/7i4Qf9BgwYxa9as/DTfRZ6nnXYan332WbHlMiaQvPlCFaXXLzkZJo8/wE3Dq6FVqpKU\nBJMnh2/wPxrrZMYDA0VkkIicJCITcd1oLwKIyDQRmZaXWURGiMhlItLKu90M3A285nPOiUAPERkt\nIr8XkdHA+cCEiNWqAvnXv/7F8uXLefjhh+nevTszZ85k0KBB/O1vf6Nbt27cf//9gPtiFREuuOAC\nPvjgA+6+++4C03h9W0lr1qzhtNNOIyUlhdtvv52rr76aTZs25QehWJeWlsZJJ50U7WIYU6zsbPjt\nNzcjrNR+/hmWuN/dKTclsrDGpbRtq2zcCCkpoS1nAcH0qYX6BgwHNgNZuOnJ5/nclwqk+hyPBL4C\nDgC/AV94j6/id86rgXW48ZlvgL7BlCXWx2TK48ILL9ScnJyA9xVVt7wxnR07dmiXLl00Nzc3bOUL\nh0D12r17tyYmJubXrbxsTCZ04qFeRY2jlLZu06apVqmimpCgWqOGOy7RgQOqM2aoXnSRe/AJJ6h6\nn9kLumaVa3yHIMdkonJlTFWdxJE1Lv73dfc7nkAQLRJVnQXMKimfOSI7O7vU18y57777WL58OQBP\nP/10XFw/5aijjiI7OwyzaowJkW3bYOhQ8Hq8ychwxz17FtPNNWkS/OUvkJ4Oxx8P990HN9wA3mf2\ncJWkiJTdLr9ciS1atKjkTH6efPLJkjMZY0Jq0yZITHTBJU9SkkvPDzLffusWvNx0kxvFb94crrnG\nBZbzzoMoXYTRgowxxlRwRc4Iq78HXpwJ06bB0qUukLRq5R5wySWBdyGJMNuF2RhjKrjkZDcDrEoV\nSEiAGjVg8jNZJJ99nNuaat8+eOIJtz3VDTdEu7gFWEvGGGPCKFR7hKW0SyOz8ZscyjhE33XjSE6u\nBjIBzjgD2rXLH2upaKwlUww3gcKY4Nn/GeOr3HuE7d8P//gHdOoEp53GgO1PcFLSRpKP9vrObr4Z\n2revsAEGLMgUKTExkQzfUTZjgnDo0CGqVrUOAlNwRlhOzpEZYSWucVF1DwA31jJ4sAs2f/8713T+\niQdPftPNAiin1NTILBC1IFOExo0b89NPP3Hw4EH7dWqCkpuby/bt2wtdXsBUTnkzwnzlzQgLaNcu\nmDgRTjsNXnnFpV13nRvQ//JLGDmS3xIbhrXM4WA/uYpQt25dAH7++WcO+U/r8GRmZlK9evVIFiti\n4rVu4a5XrVq1aNgw9r4ITOgFvUfYggWuS2zOHJfh7LOhSRN3X/36rqsshlmQKUbdunXzg00gqamp\ncbOtir94rVu81suEVij2G8ubETZwoBsyKbBHmO91ju6/H9avd31pgwa5lkwcse4yY4wJk5QU6NgR\n2raFjd8eJqXee3D55dCsGVXzNmudMcPtK/bMM3EXYMBaMsYYE1bJ+gt9dz1L8tlT4ZdfXFPmttuO\n7BHjc1nxklSUnZxLw1oyxhgTajk5biAfqJWzj2u3PgEdOsA778APP8Bjj3G4kkwQsSBjjDGhsmMH\nPP44tGzpxliArTXb0LfzL+7y6336hGT6cSyx7jJjjCmvFSvcmMrMmW6GWPfu8Kc/5d/9W1Kj6JUt\nyizIGGNMWRw8CNWquc3E3n0X3n7bLZwcNgwCXOK7srLuMmOM8VPsFSi/+w5GjYJmzeD9913aXXe5\nGWLPPWcBxo+1ZIwxxkfefmMibr+xyZMh5bpcF1Cefx7mz4eqVaFvX3cxMHCLJosQizPCQsmCjDHG\neIq8AmUPJXnkSNfEeeght2iyadPoFjZGWJAxxhiP229Mycg4sqtxUqKy6YcEkufPd1ebtA1QS8XG\nZIwxBuDQIVqseYdD+7MKJOfvN9aypQWYMrAgY4wxAMuXkzzsSiY3eoBEOUzVBHVXoHxJynWxscrO\nwrIxpnLasMFtrV+rFowbB+eeCx99RMr55/NClypkZMDcueW7mqWxlowxpjJRhUWL4IoroHVrN3Us\nb0dkEbjgAqhShaQkqFfPAkwoWJAxxlQeDz3kVuN/+qnbYn/LFpg0KdqlimvWXWaMiV+7drnWykUX\nuQ0q//hHN/U4JQVq1Ih26SqFqLRkRGS4iGwSkUwRWSkiXYvJ21dE5ovIDhHZLyLLReRyvzwDRUQD\n3OLv0o7GmJKtWwe33ALHHutaLPPmufSTToIhQyzARFDEg4yI9AMmAo8C7YElwFwROa6Ih3QD/gdc\n6uX/EHg7QGA6CDT1valqZuhrYIyp0FJSXDCZOtVtUpmWBvfdF+1SVVrR6C4bBUxV1Sne8QgR6QUM\nA0b7Z1bVO/ySHhSRS4ErgE8KZtVAOw0ZY+LZ4cNuy5c+fdzg/amnwtixbqPKxo2jXbpKL6JBRkSS\ngA7AU353zQfOKcWp6gB7/NJqiMgWIAFYDfxVVVeVtazGmAouIwP++U948knYvNntKdazJ/zlL+U+\ndWXfbyyURFUj92QixwA/Ad1U9WOf9L8B16lqmyDOcSswDjhVVbd4aZ2B1sAaXAC6A7gEOF1Vvwtw\njiHAEIAmTZp0eOONN8pUn/T0dGrXrl2mx1Z08Vo3q1dsCVSvKllZ/G7WLH43ezZJe/bw28kn88Of\n/sSuzp2hSuxMmI319+z8889fqapnlphRVSN2A44BFOjqlz4GWBfE46/Cjb1cXkK+BCANeKakc3bo\n0EHLauHChWV+bEUXr3WzesWWAvXKzj7y9/jjVXv1Uk1NVc3NjUbRyi3W3zNghQbxvR/pMZmdQA7g\nv8SpMbC9uAeKyFXAdOAGVX2vuLyqmiMiK4BW5SirMaYi+P57eOop1x329dfuQmGrVxfaXr97d/fX\nuroqloi2LVU1G1gJ9PS7qydulllAIvJH4DVgoKrOKul5RESA04Bfyl5aY0xUrVnDSQ8/7Fbmv/IK\nXHghHDjg7ivm+i2mYonG7LLxwHQR+QxYDNyC60Z7EUBEpgGo6g3ecX9cC+Zu4GMRyWsFZavqbi/P\nGGAZ8B1QF7gdF2SGRahOxphQWrkSzjyTo2vWhLvvhpEj7fotMSriQUZVZ4rI0cADuPUsXwKXqDeI\nD/ivl7kFV84J3i3PIqC79+/6wEu4brjfgFXAear6WTjqYIwJsdxc+OAD+Oknt4jyjDPgxRdZ1qwZ\nXS67LNqlM+UQlW1lVHUSEHDDIFXtXtxxEY+5E7gzFGUzxkTQoUMwc6bbBfmrr9walyFD3CyxoUM5\nbAMsMS925vsZY+LLRx+58ZaUFHc8fTp88UVMTUM2JbMNMo2pBCrMzKvsbNi/H44+Gpo0cbdnnoFL\nLy13cMnOduszt22zLforEvvJYIwJv+xsmDLFtVxGjHBpbdvCsmXQu3e5A8z06bB8udum7IQT3LGp\nGCzIGGPCJzsb/vEPaNPGjbU0aXKkeyxEtm2DoUPd3IGcHNeaGTrUpZvosyBjjAmfRx6BwYPdRpUf\nfuhaLhdfHNKn2LQJEhMLpiUluXQTfTYmY4wJnexsePVVt9V+ly5uJ+ROnaBXL7dDchi0aOEmqfkX\no0WLsDydKSVryRhjys93zGXIEHj9dZeenOxaLmEKMHlPMXmyG9ZJSHDXI5s82Qb/KwoLMsaY8nnj\njSPBpUkT1y32/PMRLUJKCnTs6OYSbNwY8mEfUw7WXWZMJRDy6b3Z2a7pULUq/PyzCy4vvBDWbrGS\nJCW5m7VgKhZryRgT50I6vffQIZ5sM4VtdVvDjBku7fbbjwzoRynAmIrLgowxcSxk03tzc932Lyef\nzD3fDmF3UjI0b+7uq1q1zMGle/cjC0VNfLIgY0wcC9n03uuug/79oUYNRp/yHsPbL4Vu3UJWThO/\nLMgYE8fKNb13+XK3BQzAwIGun23VKpY27G3dYiZoFmSMiWNlmt779ddw5ZVufctzz7m0iy6C6693\nJzGmFGx2mTFxLiXFTfzKyIC5c4sJMFu2wNixMG0a1KoFDz0Et90WyaKWS9Q3/zQBWZAxphIIanrv\n8OGwYIG7CuXo0dCwYcBsttuxKQ3rLjOmggr7zKv9+11r5Ycf3PGECfDtt/D000UGGNvt2JSWBRlj\nKpusLHcNlxNPhDFj4L33XHqrVnCc/9XPjwjHbsfZ2fDbb7ZjcjyzIGNMZfL66/D738Mdd7hLHS9b\nFvS4S6h3O7ZWUeVgQcaYymThQmjQAObPd+MvHTsG/dBQ7nZs14CpPCzIGBPPVq2CHj1IfeIzN/tq\nwgT4/HOtO7yMAAAgAElEQVTo2bPUa11CuduxXQOm8rAgY0wIVZhtUn7+GW68ETp0gLVr3TG4qcnl\nuNRxqHY7tmvAVB4WZIypoMo8KD5+vNt6f8YMuOsu2LABrrgiZOVKSoJ69co3fdmuAVN5WJAxpgIq\n9aB4bi6oun9nZroV+t98A08+CfXrh728ZWHXgKkcLMgYU8GUelB88WLOuPVWmDXLHY8eDbNnuynK\nFVwoWkWmYotKkBGR4SKySUQyRWSliHQtJm9fEZkvIjtEZL+ILBeRywPku0pEvhaRLO/vleGthTHh\nEfSg+KZN8Mc/QpcuVNu50225D7Z5palQIh5kRKQfMBF4FGgPLAHmikhRq8C6Af8DLvXyfwi87RuY\nRKQzMBOYAbTz/r4lIsHPzzSmgghqUPzpp916l/ffhzFjWD5tmtvU0pgKJhotmVHAVFWdoqrfqOoI\n4BdgWKDMqnqHqo5T1c9UdYOqPgisBHxHMkcCC1X1Ee+cjwCpXroxEROKFexFDoo3PHwk+jRr5q7v\n8t13MHYsuTVqhKYCxoRYRIOMiCQBHYD5fnfNB84pxanqAHt8jjsHOOe8Up7TmHIJ5Qr2QoPiTeZD\n+/bw97+7DP37w6uvumATYamptuOxCV6kd2FuCCQA2/3StwMXBnMCEbkV+B3g+xFOLuKcAYcTRWQI\nMASgSZMmpJbxE5Oenl7mx1Z08Vq3cNVr9+4kBg/uSG6uu95KRgYMHpxDrVrLadAgu0znPHiwHS0y\n15N4xR2wfDkZxxzDhkOH2BWg/LH6fo0d6/4WVfRYrVcw4rluBahqxG7AMYACXf3SxwDrgnj8VcBB\n4HK/9GwgxS9tAJBZ0jk7dOigZbVw4cIyP7aii9e6BapXt27uVh5LlqjWravq5hG7W716Lr2snjlx\ngh4mwZ34ySdVMzOLzFuZ3q94Eet1A1ZoEN/7kW7J7ARyKNzCaEzhlkgBInIVrvVyg6q+53f3trKc\n05hQCdkK9txct86lZk3W1TmL944ZypWrx0KjRqEqqjERFdExGVXNxg3a9/S7qydulllAIvJH4DVg\noKrOCpBlaWnPaUwohWQF+xdfwDnnwKhRAHxV7xwmtnreAoyJadGYXTYeGCgig0TkJBGZiOtGexFA\nRKaJyLS8zCLSHzcl+V7gYxFJ9m4NfM45EeghIqNF5PciMho4H5gQqUoZU+YV7Lt3u6tSnnmmW/ty\n7rlhLacxkRTxyy+r6kwRORp4AGgKfAlcoqpbvCz+62VuwZVzAgWDxiKgu3fOJV4w+j/gQeB7oJ+q\nLg9XPYwJJKjLHPtasMDNFNu9G0aMgAcfrLDbwBhTFkEHGW/6cV+gF9AJ1/qoDuwC1uO+9Geq6tcl\nnUtVJwGTirive3HHxZxzFhCoK82Yiicnx/WrtWwJ7drBU0/B6acXyFIZJh6Z+FdikBGRmsA9wG3A\nUcA3wGfADiADaAC0AG4FHhCRT4H7VHVxuAptTChlZ7spx9u2RWAPrT174IEHXLfYBx/A8cfDf/8b\n5ic1JnqCacl8j5u99TfgTVXdVVRGETkXuB6YJyJ3qerk0BTTmPDIW0Ap4hZQTp4cpt2Ac3Pd4sk/\n/9l1jd12m5uOlpQUhiczpuIIZuB/mKq2V9UXigswAKq6WFWHAScCq0NSQmPCJGKXAN68Gbp0gZtu\ngjZt3CyyiRMtwJhKocSWjKq+U9qTqup2bI2KqeDydjvOyDiSlrfbcVm7zQqMo6i6JlKDBnDwIEyd\n6ppJ5bgypTGxJuKzy4ypKMJ2CeC8rrFp02D+fKhbF1atsi34TaUUsp9UItJBRF4J1fmMCbewXAJ4\n9eojXWPZ2bBzp0u3AGMqqVC225vj9gszJmaE7BLAmZlw113QoQNs2OC6xj75BJo2DWVxjYk51l1m\nKr1SL6AMJCEBFi6EQYPg8cdtQaUxnmDWyeREoiDGxJydO91e9Q8/DEcdBUuWQPXq0S6VMRVKMC2Z\nw8DnwMIS8p0E2PVfTfxThddfh5EjYe9e6NkT+vSxAGNMAMEEmTRgu6r+tbhM3lb8FmRMfNu8GW65\nBebNg06dYMoUOPXUaJfKmAormIH/lcCZQZ7PptCY+PbnP8PixfDss/DppxZgjClBMC2ZZ4Bg9iH7\nELeHmTExpcSNKNesgXr1oHlz+Pvf4emn4dhjI1AyY2JfiS0ZVf1KVacFkS/DZ7t+Y2JfRgaMHu2m\nJY8e7dKaNbMAY0wp2BRmYwJZuBCGDHFrXm680W3Fb4wptRJbMiJS6sF8EWkqIp3KViRjomzGDOjR\nw80iW7AAXnnF7T9mjCm1YAb+nxeRNSJyi98ljwsRka4i8hKwATgtJCU0JhJU3Rb8AL17w0MPQVqa\nCzbGmDILprusJXA38BDwrIh8A6zBXbQsC3chsxNwM9DqAR8DPVV1SVhKbEyobd0Kt97q9pX54gu3\noeVfi52xb4wJUjBb/R8EHhKRxzhy+eWOFLz88jpgIu7yy+vCV1xjQkgVXn4ZRo2Cw4fdyn3bht+Y\nkAp64F9VD4nIAuBdVc0MY5mMCb89e+C662DuXDj/fPjHP9ylMY0xIRXMwH+CiIwVkb24C5HtE5HZ\nImI7AJrYVbs2pKe7RZUffWQBxpgwCaYlcwvwNyAVt4fZCbjtY/YBN4atZMaE2q+/0vqpp+C009xs\nsUWL7DovxoRZMB3Qg4EpqtpDVf+iqtcAtwLXi4hdpNzEhjlz4JRTSJ4/H5YudWkWYIwJu2CCzAnA\nW35pM4EE4PiQl8iYUNqzB66/Hq66Co47jhWTJ8Oll0a7VMZUGsEEmdq4rjFf+72/dUJbHGNC7M47\nYeZMd92XZcs42MK21zMmkoKdr9lMRE7Iu+FaN4XSvftKJCLDRWSTiGSKyEoR6VpM3qYi8rqIrBOR\nHBGZGiDPQBHRADe7wEdltG8f/PKL+/ejj8Ly5TBmDCQmRrdcxlRCwU5hnlVE+jsB0hKKO5GI9MOt\nqRkOfOr9nSsiJ6vqDwEeUg3YCYwDhhRz6oPAib4JNtW6Elq40O011rKlmzV2zDHuZoyJimCCTKhn\nkI0CpqrqFO94hIj0AoYBo/0zq+pm4HYAEbm6mPOqqm4LcVlNrDh4EO69101JbtXKLaw0xkRdMCv+\nXw3Vk3mz0ToA/lvazgfOKefpa4jIFlxLajXwV1VdVc5zmliwbh1cfjl89x3cfjs89hjUrBntUhlj\niPxW/w1xQWC7X/p24MJynHc9cBNuT7U6wB3AYhE5XVW/888sIkPwut6aNGlCaolXrQosPT29zI+t\n6GKpbgkHD3JqrVpsGT+eve3bw2efFZk3lupVGlav2BPPdStAVSN2w+13pkBXv/QxwLogHv8+rqut\npHwJQBrwTEl5O3TooGW1cOHCMj+2oqvwdVuxQvWaa1QzM0v1sApfrzKyesWeWK8bsEKD+N6P9G6A\nO4EcINkvvTGFWzdlpqo5wAqgVajOaSqInBzXHdapEyxeDN9/H+0SGWOKEdEgo6rZwEqgp99dPYGQ\nXRpARAR3PZtfQnVOUwH89BP07An33Qd9+8KXX8LJJ0e7VMaYYkTj8svjgeki8hmwGLc32jHAiwAi\nMg1AVW/Ie4CItPP+WRfI9Y6zVfVr7/4xwDLgOy/P7bggMywSFTIRMnCgW/Py8st0f/VGuFKoDF3a\nxsSyiAcZVZ0pIkcDDwBNgS+BS1R1i5fluAAP858l1hvYAjT3jusDL+G64X7z8p+nqkWPAJvYkJHh\nrvVSpw48/7y7BkybNjAt2gUzxgQjGi0ZVHUSMKmI+7oHSCt2J0NVvRO4MySFMxVHWhpce63bNfn1\n16F162iXyBhTSnYZQFPxqMJzz8FZZ8HOnTBgQLRLZIwpIwsypmLZuRP69IERI6BHD1i7Fi66qFC2\n7Gz47TfYZns8GFOhWZAxFUtWFqxcCRMmwAcfQOPGhbJMn+7G/9PS3AUtp0+PQjmNMUGxIGOiLzsb\npkyB3Fxo1sxtD3PHHQEvKrZtGwwd6rLm5Lh5AUOHWovGmIrKgoyJrg0b4NxzYcgQ+O9/XVox+45t\n2lR4x/6kJJdujKl4LMiY6FCFadOgfXu3an/27IBjL/5atIBDhwqmZWe7dGNMxWNBxkTHPfe4WWMd\nOsCaNW4FfxCSk2HyZKhSBRISoEYNd5zsv1GRMaZCiMo6GWPo0wfq14fRo120KIWUFHjhBTceM3eu\nBRhjKjILMiYycnLg8cchPd1dErlrV3cro6Qkd7MAY0zFZt1lJvx27IBLLoH774ctW9zUMGNMpWBB\nxoTXkiVucH/RInjpJXjtNTegYoypFOzTbsJn9243Y6xaNVi6lO4zBtP9/GK3oTPGxBkbkzFF6t7d\n/S31dvpZWS6wNGgAs2ZBx45ukD+EbIt/Y2KDtWRMaKWlHdk1GVxLJsQBxhgTOyzImNCZPt21Wvbt\nc9vDGGMqPQsypvwyM90GYjfc4ILMqlXQrVuhbLZzsjGVjwUZU6Sgg8JHH7mZY/fe6/YfC7B4xXZO\nNqZysiBjApo/v3HJQeHHH93fyy5z13157DGoWnguie2cbEzlZUHGFLJtG4wf36booHD4sGu1tGrl\nggtA27ZFns92Tjam8rIpzKaQTZugalUlK+tIWl5QSGYb9O/vFlcOGQKtW5d4Pts52ZjKy1oyppAW\nLeDw4YKLJrOzocW2pW71/mefwauvuu2Pq1cv8Xy2c7IxlZcFGVNIcjKMGrW+cFD47D2oW9eN4N9w\nQ6nOmZLiJp61bQsbN7pjY0z8s+4yE9Af/vArqaknI+n7mT1hK8k9TobDD8N990GdOmU6p+2cbEzl\nYy0ZU6TfZ6/lze/akXzzpa6/rGrVMgcYY0zlZEHGBNRw0SKeX9WZpNxMt0VMUlK0i2SMiUFRCTIi\nMlxENolIpoisFJEir14lIk1F5HURWSciOSIytYh8V4nI1yKS5f29MmwViGe5uTBmDKeOHcvGWqcx\n9IwV0LlztEtljIlREQ8yItIPmAg8CrQHlgBzReS4Ih5SDdgJjAOWF3HOzsBMYAbQzvv7loh0DG3p\nKwFVWLGCX3r14pQdqcxZ2jRkp05Ntd2TjalsotGSGQVMVdUpqvqNqo4AfgGGBcqsqptV9XZVnQrs\nLuKcI4GFqvqId85HgFQv3QRj40b46Sc3nWz2bNb/+c9uu35jjCmHiAYZEUkCOgDz/e6aD5xTjlN3\nDnDOeeU8Z+WxYAGcdRbcfLM7rl4dxC4uZowpv0hPYW4IJADb/dK3AxeW47zJRZwz4GRZERkCDAFo\n0qQJqWXsw0lPTy/zYysEVZrNmUPLSZM4eNxxpKWkkOnVJ+brVgSrV2yJ13pBfNfNV7TWyajfsQRI\nC9s5VfUl4CWAM888U7vnXQKylFJTUynrY6MuKwuGD4dXXoE+fag1fTqdfKYnx3TdimH1ii3xWi+I\n77r5ivSYzE4gh8ItjMYUbomUxrYwnDO+ZWbC0qXwwAMwZ46tfzHGhEVEg4yqZgMrgZ5+d/XEzTIr\nq6VhOGd8WrvWbatcrx6sWAEPP+w2FTPGmDCIxrfLeGCgiAwSkZNEZCJwDPAigIhME5Fpvg8QkXYi\n0g6oCzTwjk/2yTIR6CEio0Xk9yIyGjgfmBCRGsWK1193G4g98IA7rlkzuuUxxsS9iI/JqOpMETka\neABoCnwJXKKqW7wsgdbLrPI77g1sAZp751wiIv2B/wMeBL4H+qlqwHU1lU5Ojttz7Ikn4Lzz3LVg\njDEmAqIy8K+qk4BJRdzXPUBaifNpVXUWMKvchYs3e/fCn/4Ec+fCLbfAxIm2RYwxJmJsF+Z4t3Mn\nrFwJL7zggowxxkSQBZl4tWoVtGsHLVvChg02e8wYExU2rSjeqMKTT0KHDm4NDFiAMcZEjbVk4smh\nQzB0KPzzn/DHP0L//tEukTGmkrOWTLz47Te45BIXYP72N3jjDahVK9qlMsZUctaSiRdffAGffgpT\np8KAAdEujTHGABZkYt/u3dCgAZx/PmzaBMkB9wQ1xpiosO6yWPb++9CiBXz4oTtOTqZ7d6gEe+4Z\nY2KEBZlYNWkS9OkDrVpB+/bRLo0xxgRkQSbW5ObCXXfBrbfCpZfCokXQNHSXSDbGmFCyIBNr3nsP\nxo+HESPg7bcLzSDLznYTzbZti1L5jDHGhwWZWKHe9df69IGPPoJnnoGEhAJZpk+H5cshLQ1OOMEd\nG2NMNFmQiQXr18OZZ8JXX4EIXHBBoSzbtrl1mLm5btPljAx3bC0aY0w0WZCp6D7+GDp3hq1b4eDB\nIrNt2gSJiQXTkpJcujHGRIsFmYrs9dehZ09o0gSWLYOzzioya4sWblcZX9nZLt0YY6LFgkxF9e67\ncN11rhWzZIkbZClGcjJMnuyupJyQADVquGNbm2mMiSYLMhVVr17w2GMwbx4cdVRQD0lJcVdXbtsW\nNm50x8YYE00WZCqA/FX6v/3mRut374Zq1dxlkqtVK9W5kpKgXj1rwRhjKgYLMhVE48wfoEsXdw2Y\npUujXRxjjAkJ2yCzAmi65ytu+PpetlXPJPk//wk4RTlYqamhK5cxxpSXBZkomz5mA++uPYEPmMHh\nQ7WZ/HMVbCjFGBMvrLssirZtg6FPnEgGNdhPXTKyqtgCSmNMXLEgEy0LFrDpu8MkJkmBZFtAaYyJ\nJxZkomHCBLjwQlp8NMUWUBpj4poFmUhShQcegDvvhL59Sb7vJltAaYyJazbwHyk5Oe4aMJMnw6BB\n8OKLkJBASgq88ILb0HLuXAswxpj4EpWWjIgMF5FNIpIpIitFpGsJ+bt5+TJFZKOI3OJ3/1gRUb9b\nxRo+37ABXnvNLbB86aUC2/TbAkpjTLyKeEtGRPoBE4HhwKfe37kicrKq/hAgfwvgQ+AV4HqgCzBJ\nRHao6myfrOuB7j7HOeGpQSkdOuS2R27Txm3Vf/zxhbLY2hZjTLyKRktmFDBVVaeo6jeqOgL4BRhW\nRP5bgJ9VdYSXfwrwKnC3X77DqrrN57YjfFVw28CMHNmu+Ey7dkHXrvDss+44QIAxxph4FtEgIyJJ\nQAdgvt9d84FzinhY5wD55wFniojvFVROEJGfvG64N0Sk+G2Lw+3HH12AWb0ajj02qkUxxphoiXR3\nWUMgAdjul74duLCIxyQDHwXIX9U73y/AcmAgsA5oDDwALBGRU1R1l/8JRWQIMASgSZMmpJahv2rH\njvZkZgpz5iyhQYPsAvfV2LqV0++5h6r79/PluHHsrV8/5vrE0tPTy/S6VHRWr9gSr/WC+K5bAaoa\nsRtwDKBAV7/0McC6Ih7zLfBXv7Ru3nmSi3hMbeBXYFRJZerQoYOW1rRpqlWqqFapkqM1arjjfHv2\nqDZurNqokerKlaU+d0WxcOHCaBchLKxesSVe66Ua+3UDVmgQ3/uRHpPZiRuQ959H1ZjCrZs824rI\nfxgo1EoBUNV04CugVZlLWlRhtrnd+HNzITe3ChkZFNwKpn59eOQR+PRTOOOMUD+9McbElIgGGVXN\nBlYCPf3u6gksKeJhSyncldYTF0UPBciPiFQHfo/rSgupTZvcZDFfSUmwaeoiWLjQJQwaBK1bh/qp\njTEm5kRjdtl4YKCIDBKRk0RkIq4b7UUAEZkmItN88r8I/E5EJnj5B+HGX57KyyAiT3lraVqISEdg\nFlALNwstpFq0oPBWMAcP0+K+a2HcOLeq3xhjDBCFIKOqM4GRuMH51bh1L5eo6hYvy3HeLS//JuAS\n4Dwv//3A7VpwjczvgH/h1srMAbKATj7nDJnkZPK3gqlSJZcaiYeYfOhGknu2hTlzQKTkkxhjTCUR\nlW1lVHUSMKmI+7oHSFsEFDnAoar9Q1a4IKSkwAuTlO7rnuH2veNI7tcdpv3b9ZsZY4zJZ3uXldGS\nxcq2Xh+S3LKvW2zps02MMcYYx4JMWVWpwvq//IXkHj2si8wYY4pgW/2XgyYkWIAxxphiWJAxxhgT\nNhZkjDHGhI0FGWOMMWFjQcYYY0zYWJAxxhgTNhZkjDHGhI0FGWOMMWEjWsk3dBSRHUBZ9zhriLt8\nQTyK17pZvWJLvNYLYr9ux6tqo5IyVfogUx4iskJVz4x2OcIhXutm9Yot8VoviO+6+bLuMmOMMWFj\nQcYYY0zYWJApn5eiXYAwite6Wb1iS7zWC+K7bvlsTMYYY0zYWEvGGGNM2FiQMcYYEzYWZIwxxoSN\nBRljTIUj4q4GmPfXxC4LMmUgIq1EpEm0yxEO9uGOLfH6fqk3I0l9ZibFQx3j9f0qjs0uC5KINAZS\ngDuBHcBh4BdgFjBbVQ9EsXhhk/dh0Bj+jyIiJwMnA/WAA8ByVd0U3VKFR5y8X6cAJ+Her4PAMnu/\nYpcFmSCJyFTcF9X7wC7gaKAd7sPwI/CEqv43agUsJxGpAvQBGgE1gZ+ARar6a1QLVk4ici9wHdAK\nV6ddQC6wCngdWIz7jMfUB8HeL3u/YoUFmSB4vzb2A5eo6sc+accCHYHBwPFAP1VdHbWClpGI1AFe\nBs7HfaB/BBTIABYBr6nqOhGRWPpwi8jRwGbgHlV9UUSOBc4GOgMdgOrAaFVNjVohy8DeL3u/YknV\naBcgRpwMbAKy8xK8/ww/AD+IyLvAEqAfEHNBBrgdaIMLop+LyO+BM4EuwEXAaSJys6ruiGYhy+Aa\nYJ2qvgigqluBrcBsETkd+Cvwnoi0U9WNUSxnadn7Ze9X7FBVu5VwA2oAC4CluGZ8lQB5RgCro13W\nMtbvE2BUgPQE4DzgO+A/0S5nGep1De7HwXk+9Unwub86sAwYHu2y2vtl71e0yxmum80uC4KqZgD3\n44LNNOAGETlWRGoBiEhNoBvwZfRKWTYiUhVX7qtEpJGXliAiCaqao6578Bbgd96vyVjyAa77ZZSI\ntPXqk5N3p6pm4iZwHB2l8pWavV/2fsUaCzJBUtVlwPW4LrIXcAORb4jIK8A63PjM49ErYdmo6mHg\nVSAZuFtEmvh/uIFvgebE0AWWvP7tg8BYoDXwuYjMEZHLRaSFiHQQkRHAKcD0aJa1NHzer2OAe+Ll\n/fJkAA/hupbi7f2Kq89XadjAfxl405kvBa4AMnG/VN5S1XVRLVgZeLNeqgA3Ao/ixulmATNx/eGn\nAb2Bk1T1rGiVs7xE5E/ATcA5uMHX7d7f51R1YjTLVloikghcCzwFJHHk/fqBGH2/RKSeqv7mc3w9\nMARoj/s/+TOx/X4N5Mjnaw7wBjH8fpWGBZlyEpEqqpob7XKEgojUx30Y/oSbnr0fyAI+Ax5T1eXR\nK13peN0UOUB9Vd3jBdNquLUXJwMNgE9UdXsUi1lqIlIbNzaxC6iLC5zX4r6ssnDrSpYTQ++XiJyF\na8EswP1fW+G1QvPWOB0FNMNN+Y2Z98ubHZehqju94/q49+tK4CzcD9SDxODnqzQsyFRiIlIX2K8+\n/wm8L+PqQG3gVOBArP3n9xbz3Q30AFYAD6rq2uiWqvxE5AJgNG5m0mJgkKr+IiJH4QJoM6BqDL5f\njwL3AqlAIq77eR5QH5igqrWjV7qyE5H/AWtU9U7vWHCfrRbAbu+vqOqS6JUy/CzIVGIiMhn3K+oz\nYIuq7guQ5yivJRAzc/hF5HPch3g+rkuzNW7G0nqfPHVUdX+Uilhq3hfUt8B/gE9x43+P4H7lt8N1\nwzymqquiVsgyEpFzceMsT+MCyx9wCxab4VrT9wMrNYZW/XvvVybQSVVXeT98xuFmp27FLXV4UFXT\no1jMiLAgU0mJyLXADGAf7gv5v7hfj2uBn1Q1w+uaeQ34q6qmRa2wpSAiA3CtmK6qutf7sM/H1Wlg\nXrAUkYnAM6r6fVQLHCQRGYir11nee3Mx8E/cbKw0XCBtAPRS1Z+iVc6yEpEhQFfgBlyrrCdu7GID\n7v9oJnBTDL1fg3GLSluLSEvcGEwGMBs3saEPbvJQv3gPNDa7rPLqgbv86xnAJNyA+GvAW8ADItID\nt1fbJbESYDx9gQ+8AJPktb4eBc4VkVZegOkGjIiVLyxPP+Adbzo9uFXw24ErVXUwbp1WTSDmpsF6\nXbT/xAWXO72pylVxewNehvt/+l2MvV9DgI+9f/fHrfLvr6oTVHUYLph2xHWZxTULMpWQNyi+Cdir\nqhtV9SlVbYsbjFwEDADeBJ4lhqaLikg14BDwm9diyRaRqqq6EFffW7ysQ3DBNCaISHVca3OlT3JP\nYLI3JiPAN8DXuCm+MUVVc1X1EDAZGC4iycBwYI6qfq+qL6vqoOiWMngiUgP33XqBiHwA3IPbRPcn\nb42M4N7Lb3A/FuKadZdVUt5gcRN1eyYlAYf8JgD0A/4FnKExsh+b9+FtD5yvqk/7jiOJyKW4llp7\nXH/4paq6OHqlDZ5Xr98BtVX1G+/4WGC7qmZ5eWoD3+PqtSJ6pS0fERmO2+n8ROBsVV2Rt3AxykUL\nmvf+tMB1//XCrWl6SFUX+OSpjVvpf5mqrgx4ojhhe5dVUqq6B9jj/Tsb8rstxPtA1wUyYyXAQP5+\ncl94N3/zcTOy5gL7YiXAQH69tvod/+B9meW9b1fh3q+YDTCel3FjFtWBrwBiKcBA/vuzEdgoIv/C\nLbTM6+bMe7+uAQ7He4ABCzLGh996nzrAmGiVJRR8WjGiqodEZAZussPYqBYsRHxanlfgugL/HsXi\nhISqZonIPbhWW0aJD6jgvB9w3/ol98VtmhlTi0rLyrrLTEDeKuWceFloCvndGGcCG1V1V7TLEype\nvY4DduQtYjQVl/d+NQd+1Ti92KEvCzLGGGPCxmaXGWOMCRsLMsYYY8LGgowxxpiwsSBjjDEmbCzI\nGGOMCRsLMsb4EZErRGRUgPSxIlIhpmOKyFQRUe+WGobzP+Bz/h9DfX5TeViQMaawK4BCQQb4BxVr\nr6ltuPIMD8O5/+md+8MwnNtUIrbi35ggqeqPuN10K4osVV0WjhN7lwv4SUR2hOP8pvKwlowxPkRk\nKm4X6mY+3UWbvfsKdJflHYvI70VknogcEJEfRORG7/4UEVknIukislBETgzwfKeLyHsiskdEMkRk\nsWEtq6YAAAM3SURBVIh0LUf5q4jIfhH5m1/6UV5ZB3jHrUXkbRH5VUQyvXK/5e3QbUzI2H8oYwp6\nGGiEu+zB5V5aVgmPeQuYAjyF67p6RURaAd1xlxVOxO1T9TruGiIAiMgZwCe4i1cNxl3v/RbgIxE5\np4ybJ7bGXTrb/wqZ7b2/eenvA3uBYcBO3FUoL8F+eJoQsyBjjA9V/d7rIsouRVfUk6o6DUBEVgC9\ngaFAi7xLWotIU2CiiByvqlvyHgf8APTw2Ql7HvAl8Ffc2FBpneH99d+Juj0uWH4jIg1xlwHuo6rv\n+eR5vQzPZ0yx7FeLMeU3N+8f3iUUfgWW5QUYzzrv77GQf2GrbrhWUK6IVPW6qgT4CDivjGXpgNt4\n0f8SzGcAX3kXB9uF24p+nIgM9lpdxoSFBRljym+P33F2EWngrpMC0ABIwLVYDvndbgOO8q47Ulpn\nEPh6Ou3xusq8SwT0BFYAjwHfishGERlWhuczpljWXWZMdOwFcoHngWmBMpT2MgveFvLtgBf80hvj\nLgT2vM+5NwI3eI85HRfYJonIZlWdizEhYkHGmMKygBrhfAJVPSAin+C+4L8I0XV7TgTqA/5XkhyB\n67UodJVTr1Wz2lt8ejNwKj7df8aUlwUZYwr7GmjgdR+twF3WOC0MzzMK+BiYJyIvA78ADXFdXgmq\nem8pz5c36D9IRLbixob+gJuSDXCmiHyBG/SfCMwENuC67QYCh4H/lbk2xgRgQcaYwv4BdAIexbUM\ntuCuZBhSqvqFiJyFu8z1M0A94P/bu0OcCIIgCsN/HYNkE1ZwAfYEJASHBreHwHKBtTgMGoFZT7jE\ncgEkCQlmDYYUouYEu1Mkk/k/1+bZl+6pnv6ivqk8HhC5Ar6psekNNcq8pd6TfwZuM/MhIj6pqbY7\nYAH8AO/A9RzenNf/8mVMaYKGS6MXwBl16vUbEa/U4mqE/KB2OE/AZWYujs3UPDldJk3XKTWN9jas\nz4GxdiL3Q/Z6pDzNlDsZaYIiYkl9vwHYU0deH8BNZr6MkH9C/QUA6mLq7thMzZMlI0lq43GZJKmN\nJSNJamPJSJLaWDKSpDaWjCSpjSUjSWpjyUiS2lgykqQ2f5ajigTbLyD9AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x11a48de80>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a: -0.41 ± 0.08\n",
-      "T2: 57.33 µs ± 19.42 µs\n",
-      "c: 0.45 ± 0.09\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# arrange the data from the run\n",
     "\n",
@@ -729,7 +522,7 @@
     "    data[ii]=float(result.get_counts(key)[keys_0_1[1]])/shots\n",
     "    sigma_data[ii] = np.sqrt(data[ii]*(1-data[ii]))/np.sqrt(shots)\n",
     "    \n",
-    "fitT2cpmg, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([-1,10,0], [0, 150, 1])) \n",
+    "fitT2cpmg, fcov = curve_fit(exp_fit_fun, xvals, data, bounds=([-1,10,0], [1, 150, 1])) \n",
     "ferr = np.sqrt(np.diag(fcov))\n",
     "\n",
     "plot_coherence(xvals, data, sigma_data, fitT2cpmg, exp_fit_fun, punit, '$T_{2cpmg}$ ', qubit)\n",
@@ -769,23 +562,14 @@
    "source": [
     "%run \"../version.ipynb\""
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:QISKitenv]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-QISKitenv-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Compilation for the backend was causing the identities used in the relaxation_and_decoherence notebook to be optimized out. This change puts barriers between the identities operations to prevent that.