### PR TITLE
Removing unnecessary version checks

### DIFF
--- a/DSX.ipynb
+++ b/DSX.ipynb
@@ -45,9 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# This cell does some preparatory work to set QISKit up on the IBM Data Science Experience. \n",
@@ -66,7 +64,6 @@
     "\n",
     "# DO NOT CHANGE THE FOLLOWING assertions\n",
     "assert os.environ[\"IBMQE_API\"] != \"PUT_YOUR_API_TOKEN_HERE\", \"QX_API_TOKEN not updated!\"\n",
-    "assert sys.version_info[0:2] >= (3, 5) , \"This code requires Python 3.5 or beyond!\"\n",
     "\n",
     "# Install qiskit \n",
     "!pip install qiskit\n",
@@ -200,7 +197,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -214,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/advanced_qiskit/beginners_guide_composer_examples.ipynb
+++ b/appendix/advanced_qiskit/beginners_guide_composer_examples.ipynb
@@ -35,9 +35,7 @@
     "from IPython.display import Image\n",
     "\n",
     "from qiskit import QuantumProgram\n",
-    "from qiskit.tools.visualization import plot_histogram\n",
-    "\n",
-    "assert sys.version_info >= (3,5), \"Only Python 3.5 or greater supported.\""
+    "from qiskit.tools.visualization import plot_histogram"
    ]
   },
   {
@@ -1067,7 +1065,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/advanced_qiskit/compiling_and_running.ipynb
+++ b/appendix/advanced_qiskit/compiling_and_running.ipynb
@@ -46,11 +46,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# Import the QuantumProgram and our configuration\n",
     "import math\n",
     "from pprint import pprint\n",

--- a/appendix/algo_app/classical_optimization.ipynb
+++ b/appendix/algo_app/classical_optimization.ipynb
@@ -126,14 +126,11 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.axes as axes\n",
@@ -242,7 +239,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Computing the weight matrix from the random graph\n",
@@ -1462,7 +1461,9 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#Setting up a quantum program and connecting to the Quantum Experience API\n",
@@ -7865,7 +7866,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/etc/quantum_magic_square.ipynb
+++ b/appendix/etc/quantum_magic_square.ipynb
@@ -60,11 +60,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -386,9 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -452,7 +445,6 @@
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -616,7 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/fourier_transform.ipynb
+++ b/appendix/more_qis/fourier_transform.ipynb
@@ -155,11 +155,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# Importing QISKit\n",
     "import math\n",
     "from qiskit import QuantumCircuit, QuantumProgram\n",
@@ -212,9 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -280,9 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -367,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/single-qubit_quantum_random_access_coding.ipynb
+++ b/appendix/more_qis/single-qubit_quantum_random_access_coding.ipynb
@@ -43,11 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -84,9 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -152,9 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -247,9 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -327,7 +316,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -404,9 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -480,9 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -614,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/single_qubit_states_amplitude_and_phase.ipynb
+++ b/appendix/more_qis/single_qubit_states_amplitude_and_phase.ipynb
@@ -116,11 +116,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -144,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -207,9 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -242,9 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -303,9 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -393,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/two-qubit_state_quantum_random_access_coding.ipynb
+++ b/appendix/more_qis/two-qubit_state_quantum_random_access_coding.ipynb
@@ -72,11 +72,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -151,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -266,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -394,7 +385,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -494,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/vaidman_detection_test.ipynb
+++ b/appendix/more_qis/vaidman_detection_test.ipynb
@@ -80,11 +80,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -299,7 +294,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -321,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/appendix/more_qis/wigner_functions.ipynb
+++ b/appendix/more_qis/wigner_functions.ipynb
@@ -45,15 +45,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON\n",
-    "import sys\n",
-    "if sys.version_info < (3,0):\n",
-    "    raise Exception('Please use Python version 3 or greater.')\n",
-    "import numpy as np\n",
-    "\n",
     "# importing the QISKit\n",
     "from qiskit import QuantumCircuit, QuantumProgram\n",
     "import Qconfig\n",
@@ -675,9 +671,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py36chem",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py36chem"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -689,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/hello_world/quantum_emoticon.ipynb
+++ b/hello_world/quantum_emoticon.ipynb
@@ -235,7 +235,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%run \"../version.ipynb\""
@@ -258,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.3"
   },
   "toc": {
    "colors": {

--- a/index.ipynb
+++ b/index.ipynb
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/algorithms/bernstein_vazirani.ipynb
+++ b/reference/algorithms/bernstein_vazirani.ipynb
@@ -75,7 +75,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -114,11 +113,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -342,9 +336,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py36chem",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py36chem"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -356,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/algorithms/deutsch_josza.ipynb
+++ b/reference/algorithms/deutsch_josza.ipynb
@@ -65,14 +65,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -96,7 +93,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n = 15 #the length of the first register for querying the oracle "
@@ -262,7 +261,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%run \"../version.ipynb\""
@@ -271,16 +272,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py36chem",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py36chem"
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/algorithms/grover_algorithm.py
+++ b/reference/algorithms/grover_algorithm.py
@@ -8,7 +8,6 @@ Giacomo Nannicini, https://arxiv.org/abs/1708.03684.
 
 """
 
-import sys
 from qiskit import QuantumProgram, QuantumCircuit
 from qiskit.tools import visualization
 
@@ -107,10 +106,6 @@ def inversion_about_average(circuit, f_in, n):
 # -- end function
 
 if (__name__ == '__main__'):
-    if (sys.version_info.major < 3):
-        print('This software requires Python 3.')
-        sys.exit()
-
     # Make a quantum program for the n-bit Grover search.
     n = 3
     # Exactly-1 3-SAT formula to be satisfied, in conjunctive

--- a/reference/algorithms/iterative_phase_estimation_algorithm.ipynb
+++ b/reference/algorithms/iterative_phase_estimation_algorithm.ipynb
@@ -70,13 +70,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "if sys.version_info < (3,0):\n",
-    "    raise Exception(\"Please use Python version 3 or greater.\")\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import scipy as sp\n",
@@ -419,9 +417,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "py36chem",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py36chem"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -433,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",

--- a/reference/approximate/quantum_chemistry.ipynb
+++ b/reference/approximate/quantum_chemistry.ipynb
@@ -111,11 +111,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -1019,9 +1014,9 @@
   "anaconda-cloud": {},
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python QISKitenv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "qiskitenv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1033,7 +1028,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/games/battleships_with_partial_NOT_gates.ipynb
+++ b/reference/games/battleships_with_partial_NOT_gates.ipynb
@@ -69,16 +69,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "from qiskit import QuantumProgram\n",
     "import Qconfig"
    ]
@@ -111,9 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -200,9 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -236,9 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -263,9 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -346,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -665,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/games/quantum_counterfeit_coin_problem.ipynb
+++ b/reference/games/quantum_counterfeit_coin_problem.ipynb
@@ -49,11 +49,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -204,9 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -274,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -382,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/qcvv/process_tomography.ipynb
+++ b/reference/qcvv/process_tomography.ipynb
@@ -44,14 +44,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "import numpy as np\n",
     "\n",
     "# importing the QISKit\n",
@@ -274,7 +271,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "backend = 'local_qasm_simulator'\n",
@@ -431,7 +430,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# process tomography set for quantum operation on qubits 0 and 1\n",
@@ -445,6 +446,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -608,7 +610,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }

--- a/reference/qcvv/relaxation_and_decoherence.ipynb
+++ b/reference/qcvv/relaxation_and_decoherence.ipynb
@@ -36,13 +36,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
     "from qiskit import QuantumProgram\n",
     "import Qconfig\n",
     "import numpy as np\n",
@@ -53,7 +51,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# function for padding with QId gates\n",
@@ -68,7 +68,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# backend and token settings\n",
@@ -94,7 +96,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Select qubit whose T1 is to be measured\n",
@@ -133,7 +137,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# run the program\n",
@@ -549,7 +555,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -560,6 +568,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/qcvv/state_tomography.ipynb
+++ b/reference/qcvv/state_tomography.ipynb
@@ -46,13 +46,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
     "import numpy as np\n",
     "    \n",
     "# importing the QISKit\n",
@@ -122,7 +120,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "bell_result = Q_program.execute(['bell'], backend='local_qasm_simulator', shots=1)\n",
@@ -314,7 +314,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "bell_tomo_data = tomo.tomography_data(bell_tomo_result, 'bell', bell_tomo_set)"
@@ -341,7 +343,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "rho_fit = tomo.fit_tomography_data(bell_tomo_data)"
@@ -528,7 +532,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }

--- a/reference/qis/entanglement_revisited.ipynb
+++ b/reference/qis/entanglement_revisited.ipynb
@@ -81,11 +81,6 @@
    },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -1027,7 +1022,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#%run \"../version.ipynb\""
@@ -1060,7 +1057,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/qis/superposition_and_entanglement.ipynb
+++ b/reference/qis/superposition_and_entanglement.ipynb
@@ -42,14 +42,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -65,7 +63,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# useful additional packages \n",
@@ -86,7 +86,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def lowest_pending_jobs(api):\n",
@@ -104,7 +106,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from IBMQuantumExperience import IBMQuantumExperience\n",
@@ -136,7 +140,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "zero = np.array([[1],[0]])\n",
@@ -272,6 +278,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -483,7 +490,9 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "state_overlap = lambda state1, state2: np.absolute(np.dot(state1.conj().T,state2))**2"
@@ -909,7 +918,9 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "result = Q_program.execute(circuits[4:6], backend=backend, shots=shots, max_credits=3, wait=10, timeout=240)"
@@ -1096,7 +1107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -1118,7 +1131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/qis/teleportation_superdensecoding.ipynb
+++ b/reference/qis/teleportation_superdensecoding.ipynb
@@ -35,14 +35,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -58,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# useful additional packages \n",
@@ -336,7 +336,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "circuits = ['teleport']\n",
@@ -659,7 +661,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/tools/getting_started.ipynb
+++ b/reference/tools/getting_started.ipynb
@@ -39,14 +39,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -62,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister\n",
@@ -91,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Create a Quantum Register called \"q\" with 3 qubits\n",
@@ -245,7 +247,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "backend = 'local_qasm_simulator' \n",
@@ -346,7 +350,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from IBMQuantumExperience import IBMQuantumExperience\n",
@@ -356,7 +362,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def lowest_pending_jobs(api):\n",
@@ -393,6 +401,7 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -479,7 +488,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -501,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/tools/quantum_gates_and_linear_algebra.ipynb
+++ b/reference/tools/quantum_gates_and_linear_algebra.ipynb
@@ -36,14 +36,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -59,7 +57,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Useful additional packages \n",
@@ -72,7 +72,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister\n",
@@ -155,7 +157,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "q = QuantumRegister(\"q\", 1)\n",
@@ -1296,7 +1300,9 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "q = QuantumRegister(\"q\", 2)\n",
@@ -1915,7 +1921,9 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "q = QuantumRegister(\"q\", 3)\n",
@@ -2071,7 +2079,9 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "q = QuantumRegister(\"q\", 1)\n",
@@ -2501,7 +2511,9 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def norm(state1, state2):\n",
@@ -2600,7 +2612,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -2622,7 +2636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/tools/visualizing_quantum_state.ipynb
+++ b/reference/tools/visualizing_quantum_state.ipynb
@@ -23,14 +23,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -46,7 +44,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# useful additional packages \n",
@@ -60,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister\n",
@@ -73,7 +75,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def ghz_state(q, c, n):\n",
@@ -111,7 +115,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Build the quantum cirucit. We are going to build two circuits a GHZ over 3 qubits and a\n",
@@ -183,7 +189,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n = 2  # number of qubits \n",
@@ -229,7 +237,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def overlap(state1, state2):\n",
@@ -284,7 +294,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def expectation_value(state, Operator):\n",
@@ -387,7 +399,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def state_2_rho(state):\n",
@@ -515,7 +529,9 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n = 2  # number of qubits \n",
@@ -617,7 +633,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -639,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/reference/tools/working_with_backends.ipynb
+++ b/reference/tools/working_with_backends.ipynb
@@ -46,14 +46,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Checking the version of PYTHON; we only support > 3.5\n",
     "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "    \n",
     "try:\n",
     "    sys.path.append(\"../../\") # go to parent dir\n",
     "    import Qconfig\n",
@@ -69,7 +67,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from qiskit import QuantumProgram\n",
@@ -596,7 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since [PR#349](https://github.com/QISKit/qiskit-sdk-py/pull/349) of QISKit Core, version checking is done automatically when importing qiskit. Here I have removed this unnecessary step from the tutorial notebooks.