### PR TITLE
Add link to README.md

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "To get started we have put together a set of tutorials which can be downloaded by clicking [here!](https://github.com/QISKit/qiskit-tutorial/archive/master.zip).\n",
     "\n",
-    "Please see [README](https://github.com/QISKit/qiskit-tutorial/blob/master/README.md) for installation instruction.\n",
+    "Please see [README](https://github.com/QISKit/qiskit-tutorial/blob/master/README.md) for installation instructions.\n",
     "\n",
     "***\n",
     "\n",

--- a/index.ipynb
+++ b/index.ipynb
@@ -16,7 +16,11 @@
     "***\n",
     "\n",
     "\n",
-    "Welcome QISKitters to the Quantum Information Software Kit ([QISKit](https://www.qiskit.org/) for short)! To get started we have put together a set of tutorials which can be downloaded by clicking [here!](https://github.com/QISKit/qiskit-tutorial/archive/master.zip).\n",
+    "Welcome QISKitters to the Quantum Information Software Kit ([QISKit](https://www.qiskit.org/) for short)! \n",
+    "\n",
+    "To get started we have put together a set of tutorials which can be downloaded by clicking [here!](https://github.com/QISKit/qiskit-tutorial/archive/master.zip).\n",
+    "\n",
+    "Please see [README](https://github.com/QISKit/qiskit-tutorial/blob/master/README.md) for installation instruction.\n",
     "\n",
     "***\n",
     "\n",
@@ -101,9 +105,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python QISKitenv",
    "language": "python",
-   "name": "python3"
+   "name": "qiskitenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -115,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As the link from qiskit.org goes directly to `index.ipynb`, I add a link to `README.md` that has instruction of how to install the tutorial. This way, users can find the instruction to install the tutorial when visiting the page from the qiskit.org
