### PR TITLE
robust Qconfig template; fixed bug in retrieving Qconfig template 

### DIFF
--- a/DSX.ipynb
+++ b/DSX.ipynb
@@ -45,7 +45,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# This cell does some preparatory work to set QISKit up on the IBM Data Science Experience. \n",
@@ -75,7 +77,7 @@
     "home_dir = os.path.expanduser('~')\n",
     "qconfig_filepath = os.path.join(home_dir, 'Qconfig.py') \n",
     "\n",
-    "qconfig_template_path = \"https://github.com/QISKit/qiskit-tutorial/blob/master/Qconfig.py.template\"\n",
+    "qconfig_template_path = \"https://raw.githubusercontent.com/QISKit/qiskit-tutorial/master/Qconfig.py.template\"\n",
     "\n",
     "# We need visibility to Qconfig.py module. Add home dir in your sys.path just to be sure. \n",
     "if home_dir not in sys.path:\n",
@@ -196,9 +198,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:anaconda3.5]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-anaconda3.5-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -210,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/Qconfig.py.template
+++ b/Qconfig.py.template
@@ -1,13 +1,60 @@
+# --------------------------------------------------------------------------------
 # Before you can use the jobs API, you need to set up an access token.
 # Log in to the Quantum Experience. Under "Account", generate a personal
-# access token. Replace "None" below with the quoted token string.
-# Uncomment the APItoken variable, and you will be ready to go.
+# access token. There are two ways to set your API token
+#
+# METHOD-1:
+#    Replace "None" value of variable APItoken with the quoted token string.
+#    Uncomment the APItoken variable, and you will be ready to go.
+#
+# METHOD-2:
+#   The APIToken can be set as an environment variable in your shell session. For
+#   example, in your ~/.bash_profile or ~/.bashrc add:
+#   .. code-block:: bash
+#      export IBMQE_API="your_secret_api_string"
+#
+#   and then restart your terminal session. This will add the ``$IBMQE_API`` as an
+#   environment variable that can be accessed by the script.
+#   Once imported, you can check the values have set using print:
+#   .. code-block:: python
+#       import Qconfig
+#       print(Qconfig.APItoken, Qconfig.config['url'])
+# --------------------------------------------------------------------------------
 
-APItoken = 'my token from the Quantum Experience'
+import os
+
+# Replace 'None' with your own API token (put it within quotes)
+# Optionally, you can set the environment variable IBMQE_API as decribed in the
+# aforementioned note. NOTE: If you set your APItoken below, it will OVERRIDE the
+# value of the environment variable.
+
+APItoken = None
 
 config = {
   "url": 'https://quantumexperience.ng.bluemix.net/api'
 }
 
-if 'APItoken' not in locals():
-  raise Exception("Please set up your access token. See Qconfig.py.")
+def update_token(token=None):
+    """Update the APItoken.
+
+       :param token: The API token.(optional argument)
+              If thisis set, it must be a string. The default value is None
+    """
+    global APItoken
+
+    # If a token is given as an argument, use it.
+    if token:
+        APItoken = token
+    else:
+        # First check if APItoken is already set. If so, just use it.
+        if APItoken:
+            # Do nothing. The APItoken will override
+            pass
+        else:
+            APItoken = os.getenv("IBMQE_API")
+
+    assert (APItoken not in (None, '') and type(APItoken) is str), "Please set up a valid API access token. See Qconfig.py."
+
+# Update the APItoken
+update_token()
+


### PR DESCRIPTION
- Robust  Qconfig template - updated `Qconfig.py.template` - you can either hardcode the APItoken directly in `Qconfig.py` OR set it as an environment variable. If the token is hard coded in Qconfig file it OVERRIDES the value of the environment variable. There is also a new convenience method `update_token` to update to the current value API token. 
- Fixed a bug in retrieving the template in DSX.ipynb