### PR TITLE
Replace "QI Software Kit" with "QI Science Kit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # QISKit Tutorials
 
-Welcome to the Quantum Information Software Kit ([QISKit](https://www.qiskit.org/) for short) tutorials! 
+Welcome to the Quantum Information Science Kit ([QISKit](https://www.qiskit.org/) for short) tutorials!
 
 In this repository, we've put together a collection of Jupyter notebooks aimed at teaching people who want to use the QISKit for writing quantum computing programs and executing them on one of several backends (online quantum processors, online simulators, and local simulators). The online quantum processors connects to the [IBM Q](https://quantumexperience.ng.bluemix.net/qx/devices) devices.
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -16,7 +16,7 @@
     "***\n",
     "\n",
     "\n",
-    "Welcome QISKitters to the Quantum Information Software Kit ([QISKit](https://www.qiskit.org/) for short)! \n",
+    "Welcome QISKitters to the Quantum Information Science Kit ([QISKit](https://www.qiskit.org/) for short)! \n",
     "\n",
     "To get you started, we have put together a set of tutorials that can be downloaded by clicking [here!](https://github.com/QISKit/qiskit-tutorial/archive/master.zip).\n",
     "\n",

--- a/reference/tools/getting_started.ipynb
+++ b/reference/tools/getting_started.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## QISKit (Quantum Information Software developer Kit)\n",
+    "## QISKit (Quantum Information Science Kit)\n",
     "\n",
     "This tutorial aims to explain how to use QISKit. We assume you have installed QISKit if not please look at [qiskit.org](http://www.qiskit.org) or the install [documentation](https://github.com/QISKit/qiskit-tutorial/blob/master/INSTALL.md). \n",
     "\n",


### PR DESCRIPTION
As per the latest discussions, `QISKit` now stands for "Quantum Information _Science_ Kit". I have search for the instances where the old name was in use and replaced accordingly.