### PR TITLE
Update CODEOWNERS, adding root entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,8 @@
-# Where component owners are known, add them here.
+# Fallback codeowners for all files that do not have an explicit rule.
+* @attp, @jaygambetta, @rraymondhp
 
-reference/tools/* @ajavadia, @ewisnton, @jaygambetta
+# Codeowners for the reference tutorials.
+reference/tools/* @ajavadia, @ewinston, @jaygambetta
 reference/qis/* @attp, @adcorcol, @jaygambetta
 reference/qcvv/* @dtmcclure, @chriselectic, @jaygambetta
 reference/approximate/* @adcorcol, @antoniomezzacapo, @jaygambetta


### PR DESCRIPTION
Add a new entry to CODEOWNERS for the files that are not in `reference`.
Fix typo on name.

This is in preparation for @jaygambetta changes and automating the code reviews.