### PR TITLE
Reintroduce CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Fallback codeowners for all files that do not have an explicit rule.
+* @jaygambetta
+
+# Codeowners for individual folders and files.
+qiskit/* @jaygambetta
+community/hello_world/* @quantumjim
+community/games/* @quantumjim
+community/algorithms/* @rraymondhp
+community/terra/* @attp
+community/teach_me_qiskit_2018/* @rraymondhp
+community/aqua/* @jaygambetta


### PR DESCRIPTION
Fix #288 

As discussed, this sets Jay as the "fallback codeowner", as there might be occasional PRs that do not touch the explicitly specified paths. Please note as well that if the codeowner of a section submits a PR, he might not be able to get approval - that is partly the reason why there were more than one reviewer for each section at some point of time. There are alternative ways of solving that problem that we can look into.