### PR TITLE
community - state distribition - fix links

### DIFF
--- a/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/qubit_chain.ipynb
+++ b/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/qubit_chain.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is used representation initially introduced for _perfect state transfer_. The chain with $n$ nodes is modeled by $n$ qubits. The more compact representation with $n$ qubits for a chain $N=2^n$ nodes is discussed elsewhere, _e.g._, see arXiv:1710.03615 \\[quant-ph\\](2017) with [tutorial about topological quantum walk](https://github.com/Qiskit/qiskit-tutorial/blob/master/community/terra/topological_quantum_walk.ipynb).\n",
+    "Here is used representation initially introduced for _perfect state transfer_. The chain with $n$ nodes is modeled by $n$ qubits. The more compact representation with $n$ qubits for a chain $N=2^n$ nodes is discussed elsewhere, _e.g._, see arXiv:1710.03615 \\[quant-ph\\](2017) with [tutorial about topological quantum walk](../../terra/qis_adv/topological_quantum_walk.ipynb).\n",
     "\n",
     "### Chain model\n",
     "\n",
@@ -100,7 +100,7 @@
     "    cx a,b;\n",
     "    }\n",
     "\n",
-    "Similar method is used further with QISKit, however it may be not very optimal for hardware."
+    "Similar method is used further with Qiskit, however it may be not very optimal for hardware."
    ]
   },
   {

--- a/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/qubit_chain_mod_many.ipynb
+++ b/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/qubit_chain_mod_many.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "The method used here may be applied only for simulator and \n",
     "similar with already used in a [Qiskit tutorial](https://github.com/Qiskit/qiskit-tutorial) about \n",
-    "[visualization of quantum state](https://github.com/Qiskit/qiskit-tutorial/blob/master/qiskit/basics/qiskit_visualizations.ipynb).\n",
+    "[visualization of quantum state](../../../qiskit/basics/qiskit_visualizations.ipynb).\n",
     "The `unitary_simulator` backend is used to produce $2^n \\times 2^n$ unitary matrix\n",
     "QWalk representing quantum circuit, where $n$ is `n_nodes`. \n",
     "The complex vector with $2^n$ is initialized as initial state, \n",
@@ -98,7 +98,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [
     {
@@ -190,7 +190,7 @@
     "So, for $n$ steps of walk it is necessary to make $n$ different experiments with\n",
     "`n_step`=$1,2,\\dots,n$ \n",
     "and each such attempt could include additional series of runs to provide \n",
-    "[state tomography](https://github.com/Qiskit/qiskit-tutorial/blob/master/qiskit/ignis/state_tomography.ipynb)\n",
+    "[state tomography](../../../qiskit/ignis/state_tomography.ipynb)\n",
     "for whole process of quantum walk.\n"
    ]
   }

--- a/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/scalar_chain.ipynb
+++ b/community/teach_me_qiskit_2018/state_distribution_in_qubit_chains/scalar_chain.ipynb
@@ -104,7 +104,7 @@
     "Let us denote $S_1$ and $S_2$ swaps in all pairs for first and second partition, respectively. Without taking into account boundary, the composition of alternating swaps \n",
     "$S = S_1 S_2$ would produce double-step shifts of elements with even and odd indexes in opposite directions $2k \\to 2k+2$ and $2k+1 \\to 2k-1$. \n",
     "\n",
-    "See <a href=\"https://sketchfab.com/models/2836cf8f3a284e629ccd609137c54a04/embed\">animated staggered classical walk in 3D</a> for illustration of such a motion with boundary effects. \n",
+    "See <a href=\"https://qubeat.github.io/staggered-walk/\">animated staggered classical walk in 3D</a> for illustration of such a motion with boundary effects. \n",
     "\n",
     "For a quantum model states $|c,k\\rangle$ are mapped into $|2k+1\\rangle$. The trivial motion of basic states would be represented as $S = S_1 S_2$, where $S_1 = s(1,2)\\,s(3,4)\\dots$ and $S_2 = s(2,3)\\,s(4,5)\\dots$ are two alternating\n",
     "sequences of swaps defined for given link simply as\n",


### PR DESCRIPTION
Fix link to topological walk new path. 
Make all links to tutorial relative. 
Change link to staggered walk 3D model.
Change yet another one missed QISKit -> Qiskit