### PR TITLE
Quantum Cryptography 2 - Update

### DIFF
--- a/community/teach_me_qiskit_2018/index.ipynb
+++ b/community/teach_me_qiskit_2018/index.ipynb
@@ -19,10 +19,10 @@
     "- [E91 Quantum Key Distribution Protocol](e91_qkd/e91_quantum_key_distribution_protocol.ipynb) by Andrey Kardashin  - a tutorial on quantum key distribution based on the protocol by Ekert in 1991.\n",
     "- [Elementary Arithmetic Operations](elementary_arithmetic_operations/elementary_arithmetic_operations.ipynb) by Carlos Bravo Prieto - addition and modular exponentiation with quantum circuits which are important for Shor's algorithm.\n",
     "- [Hadamard Action](hadamard_action) by Connor Fieweger - three approaches to show equivalences of circuits.\n",
+    "- [Quantum Cryptography](quantum_cryptography_qkd/Quantum_Cryptography2.ipynb) by A. J. Rasmusson and Richard Barney  - quantum key distribution with the BB84 protocol.\n",
     "\n",
     "The others work with Qiskit (0.4.15) from time of submission.\n",
     "- [Exact Ising Model Simulation](exact_ising_model_simulation/Ising_time_evolution.ipynb) by Alba Cervera-Lierta - how to simulate time evolution at zero time. *The winner* of the Teach Me QISKit Award 2018. See [here](https://www.ibm.com/blogs/research/2018/06/teach-qiskit-winner/) for the announcement.\n",
-    "- [Quantum Cryptography](quantum_cryptography_qkd/Quantum_Cryptography2.ipynb) by A. J. Rasmusson and Richard Barney  - quantum key distribution with the BB84 protocol.\n",
     "- [Quantum Error Correction](quantum_error_correction/error_correction.ipynb) by Andrew Selzler, Yin Li, Frederick Ira Moxley III  - qubit errors and how to threat them.\n",
     "- [Quantum Machine Learning](quantum_machine_learning/QISKIT%20for%20quantum%20machine%20learning.ipynb) by Shan Jin, Xi He, Xiaokai Hou, Li Sun, Dingding Wen, Shaojun Wu and Xiaoting Wang - quantum k-means, linear system of equation, and SVM."
    ]

--- a/community/teach_me_qiskit_2018/quantum_cryptography_qkd/Quantum_Cryptography2.ipynb
+++ b/community/teach_me_qiskit_2018/quantum_cryptography_qkd/Quantum_Cryptography2.ipynb
@@ -2,12 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"../../../images/qiskit-heading.gif\" alt=\"Note: In order for images to show up in this jupyter notebook you need to select File => Trusted Notebook\" width=\"500 px\" align=\"left\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "3ZyGwuu2THJe"
    },
    "source": [
     "# Quantum Cryptography: Quantum Key Distribution\n",
+    "\n",
+    "The latest version of this notebook is available on https://github.com/qiskit/qiskit-tutorial.\n",
+    "\n",
     "***\n",
     "### Contributors:\n",
     "A.J. Rasmusson, Richard Barney"
@@ -37,22 +47,15 @@
    },
    "outputs": [],
    "source": [
-    "#import all the packages\n",
-    "\n",
-    "# Checking the version of PYTHON\n",
-    "import sys\n",
-    "if sys.version_info < (3,5):\n",
-    "    raise Exception('Please use Python version 3.5 or greater.')\n",
-    "\n",
-    "#append to system path so qiskit and Qconfig can be found from home directory\n",
-    "sys.path.append('../qiskit-sdk-py/')\n",
-    "\n",
-    "# Import the QuantumProgram and configuration\n",
-    "from qiskit import QuantumProgram\n",
-    "#import Qconfig\n",
-    "\n",
     "#other useful packages\n",
-    "import math"
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "\n",
+    "# Import Qiskit\n",
+    "from qiskit import Aer, execute\n",
+    "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister"
    ]
   },
   {
@@ -195,9 +198,8 @@
     "    output_list = []\n",
     "    output = ''\n",
     "    \n",
-    "    #start up your quantum program\n",
-    "    qp = QuantumProgram()\n",
-    "    backend = 'local_qasm_simulator'  \n",
+    "    #start up your quantum circuit information\n",
+    "    backend = Aer.get_backend('qasm_simulator')  \n",
     "    circuits = ['rs']\n",
     "    \n",
     "    #run circuit in batches of 10 qubits for fastest results. The results\n",
@@ -207,9 +209,9 @@
     "    temp_output = ''\n",
     "    for i in range(math.ceil(n/temp_n)):\n",
     "        #initialize quantum registers for circuit\n",
-    "        q = qp.create_quantum_register('q',temp_n)\n",
-    "        c = qp.create_classical_register('c',temp_n)\n",
-    "        rs = qp.create_circuit('rs',[q],[c])\n",
+    "        q = QuantumRegister(temp_n, name='q')\n",
+    "        c = ClassicalRegister(temp_n, name='c')\n",
+    "        rs = QuantumCircuit(q, c, name='rs')\n",
     "            \n",
     "        #create temp_n number of qubits all in superpositions\n",
     "        for i in range(temp_n):\n",
@@ -217,9 +219,9 @@
     "            rs.measure(q[i],c[i])\n",
     "\n",
     "        #execute circuit and extract 0s and 1s from key\n",
-    "        result = qp.execute(circuits, backend, shots=1)\n",
-    "        counts = result.get_counts('rs')\n",
-    "        result_key = list(result.get_counts('rs').keys())\n",
+    "        result = execute(rs, backend, shots=1).result()\n",
+    "        counts = result.get_counts(rs)\n",
+    "        result_key = list(result.get_counts(rs).keys())\n",
     "        temp_output = result_key[0]\n",
     "        output += temp_output\n",
     "        \n",
@@ -245,7 +247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initial key:  111111000111011000011100011001111\n"
+      "Initial key:  011001101100010111010010010111110\n"
      ]
     }
    ],
@@ -283,9 +285,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Alice's rotation string: 110110100010110010011100011000010\n",
-      "Bob's rotation string:   010101100000101010010101111010111\n",
-      "Bob's results:  011100000101011000010101011011010\n"
+      "Alice's rotation string: 111001110110111110001001000001000\n",
+      "Bob's rotation string:   010101000011110110111110100010101\n",
+      "Bob's results:  010001111001010111010101110111110\n"
      ]
     }
    ],
@@ -297,7 +299,7 @@
     "print(\"Bob's rotation string:  \",Bob_rotate)\n",
     "\n",
     "#start up your quantum program\n",
-    "backend = 'local_qasm_simulator'  \n",
+    "backend = Aer.get_backend('qasm_simulator')  \n",
     "shots = 1\n",
     "circuits = ['send_over']\n",
     "Bob_result = ''\n",
@@ -313,11 +315,10 @@
     "        Ar_temp = Alice_rotate[l*ind:l*(ind+1)]\n",
     "        Br_temp = Bob_rotate[l*ind:l*(ind+1)]\n",
     "    \n",
-    "    #start up the rest of your quantum program\n",
-    "    qp2 = QuantumProgram()\n",
-    "    q = qp2.create_quantum_register('q',l)\n",
-    "    c = qp2.create_classical_register('c',l)\n",
-    "    send_over = qp2.create_circuit('send_over',[q],[c])\n",
+    "    #start up the rest of your quantum circuit information\n",
+    "    q = QuantumRegister(l, name='q')\n",
+    "    c = ClassicalRegister(l, name='c')\n",
+    "    send_over = QuantumCircuit(q, c, name='send_over')\n",
     "    \n",
     "    #prepare qubits based on key; add Hadamard gates based on Alice's and Bob's\n",
     "    #rotation strings\n",
@@ -336,9 +337,9 @@
     "        send_over.measure(q[n],c[n])\n",
     "\n",
     "    #execute quantum circuit\n",
-    "    result_so = qp2.execute(circuits, backend, shots=shots)\n",
-    "    counts_so = result_so.get_counts('send_over')\n",
-    "    result_key_so = list(result_so.get_counts('send_over').keys())\n",
+    "    result_so = execute([send_over], backend, shots=shots).result()\n",
+    "    counts_so = result_so.get_counts(send_over)\n",
+    "    result_key_so = list(result_so.get_counts(send_over).keys())\n",
     "    Bob_result += result_key_so[0][::-1]\n",
     "    \n",
     "print(\"Bob's results: \", Bob_result)"
@@ -373,8 +374,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Alice's key: 111000110000011011011\n",
-      "Bob's key:   111000110000011011011\n"
+      "Alice's key: 101100111101011\n",
+      "Bob's key:   101100111101011\n"
      ]
     }
    ],
@@ -437,7 +438,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "encoded message:   ÊÇÎÌÏÙÑÒÌÄ\n",
+      "encoded message:   ÊÅÎÎÏÙÑÔÎÄ\n",
       "recovered message: hello world\n"
      ]
     }
@@ -521,13 +522,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Eve's results:  001111000111011000000100010001101\n"
+      "Eve's results:  011001001000100011010010010111110\n"
      ]
     }
    ],
    "source": [
     "#start up your quantum program\n",
-    "backend = 'local_qasm_simulator'  \n",
+    "backend = Aer.get_backend('qasm_simulator')  \n",
     "shots = 1\n",
     "circuits = ['Eve']\n",
     "\n",
@@ -541,11 +542,10 @@
     "        key_temp = key[l*ind:l*(ind+1)]\n",
     "        Ar_temp = Alice_rotate[l*ind:l*(ind+1)]\n",
     "    \n",
-    "    #start up the rest of your quantum program\n",
-    "    qp3 = QuantumProgram()\n",
-    "    q = qp3.create_quantum_register('q',l)\n",
-    "    c = qp3.create_classical_register('c',l)\n",
-    "    Eve = qp3.create_circuit('Eve',[q],[c])\n",
+    "    #start up the rest of your quantum circuit information\n",
+    "    q = QuantumRegister(l, name='q')\n",
+    "    c = ClassicalRegister(l, name='c')\n",
+    "    Eve = QuantumCircuit(q, c, name='Eve')\n",
     "    \n",
     "    #prepare qubits based on key; add Hadamard gates based on Alice's and Bob's\n",
     "    #rotation strings\n",
@@ -559,9 +559,9 @@
     "        Eve.measure(q[n],c[n])\n",
     "    \n",
     "    #execute\n",
-    "    result_eve = qp3.execute(circuits, backend, shots=shots)\n",
-    "    counts_eve = result_eve.get_counts('Eve')\n",
-    "    result_key_eve = list(result_eve.get_counts('Eve').keys())\n",
+    "    result_eve = execute(Eve, backend, shots=shots).result()\n",
+    "    counts_eve = result_eve.get_counts()\n",
+    "    result_key_eve = list(result_eve.get_counts().keys())\n",
     "    Eve_result += result_key_eve[0][::-1]\n",
     "\n",
     "print(\"Eve's results: \", Eve_result)"
@@ -596,14 +596,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bob's previous results (w/o Eve): 011100000101011000010101011011010\n",
-      "Bob's results from Eve:\t\t  001011000111010000010000110001000\n"
+      "Bob's previous results (w/o Eve): 010001111001010111010101110111110\n",
+      "Bob's results from Eve:\t\t  011101001001100011010010010101011\n"
      ]
     }
    ],
    "source": [
     "#start up your quantum program\n",
-    "backend = 'local_qasm_simulator'  \n",
+    "backend = Aer.get_backend('qasm_simulator')  \n",
     "shots = 1\n",
     "circuits = ['Eve2']\n",
     "\n",
@@ -619,11 +619,10 @@
     "        Eve_temp = Eve_result[l*ind:l*(ind+1)]\n",
     "        Br_temp = Bob_rotate[l*ind:l*(ind+1)]\n",
     "    \n",
-    "    #start up the rest of your quantum program\n",
-    "    qp4 = QuantumProgram()\n",
-    "    q = qp4.create_quantum_register('q',l)\n",
-    "    c = qp4.create_classical_register('c',l)\n",
-    "    Eve2 = qp4.create_circuit('Eve2',[q],[c])\n",
+    "    #start up the rest of your quantum circuit information\n",
+    "    q = QuantumRegister(l, name='q')\n",
+    "    c = ClassicalRegister(l, name='c')\n",
+    "    Eve2 = QuantumCircuit(q , c, name='Eve2')\n",
     "    \n",
     "    #prepare qubits\n",
     "    for i,j,n in zip(Eve_temp,Br_temp,range(0,len(key_temp))):\n",
@@ -636,9 +635,9 @@
     "        Eve2.measure(q[n],c[n])\n",
     "    \n",
     "    #execute\n",
-    "    result_eve = qp4.execute(circuits, backend, shots=shots)\n",
-    "    counts_eve = result_eve.get_counts('Eve2')\n",
-    "    result_key_eve = list(result_eve.get_counts('Eve2').keys())\n",
+    "    result_eve = execute(Eve2, backend, shots=shots).result()\n",
+    "    counts_eve = result_eve.get_counts()\n",
+    "    result_key_eve = list(result_eve.get_counts().keys())\n",
     "    Bob_badresult += result_key_eve[0][::-1]\n",
     "    \n",
     "print(\"Bob's previous results (w/o Eve):\",Bob_result)\n",
@@ -676,9 +675,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Alice's key:    111000110000011011011\n",
-      "Bob's key:      010000110000010010010\n",
-      "spots to check: 110011110011111101101\n"
+      "Alice's key:    101100111101011\n",
+      "Bob's key:      101101001101011\n",
+      "spots to check: 101011001111101\n"
      ]
     }
    ],
@@ -722,8 +721,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "subset of Alice's key: 110011000110101\n",
-      "subset of Bob's key:   010011000100000\n",
+      "subset of Alice's key: 1100110101\n",
+      "subset of Bob's key:   1101110101\n",
       "Eve detected!\n"
      ]
     }
@@ -792,26 +791,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3XecXVW5//HPdya9d0glCQmEUBJIABEEpAh4vUYpCuoVG/z0yhXsYEHkXkSxXzsoTVS6EhXEC0LokARSIBBIIUwKJJNkJsmkTHt+f+w9w2GYcibkzJkz5/t+vc5rdll7n2efM7Of2WvtvZYiAjMzM4CSfAdgZmadh5OCmZk1clIwM7NGTgpmZtbIScHMzBo5KZiZWSMnBcsJSZdJumk3t/2YpEdaWf+gpE+l0x+W9M/djbOdcR0t6SVJ2yS9L4vy10v6n46IrY04vibpt/mOwwqDk4I1kvSypB3pSe+19KTWL99xtSYi/hAR72qYlxSSJuXo7S4Hfh4R/SLiL3tyx+lnf9Ie2M/xklZnLouI70TEp97qvlt4v5BUlf7ONLy+kov3so7hpGBN/XtE9AMOA2YC32haQIli/N3ZB3gu30F0QtPSRNnwuirfAdnuK8Y/bMtCRKwB7gEOgsYqmyskPQpsByZKGiVptqRNkpZJOq/JbnpJukXSVklPS5rWsELSxZKWp+uWSHp/k20l6eeSKiW9IOnE5uLMrGqS9FC6eGH6H+sHJT0r6d8zyneXVC7p0Bb2d156LJvSYxuVLl8OTAT+mu67ZzPbHpoe51ZJtwC9mqx/j6QFkiokPSbpkHT574FxGfv+Srr8bWm5CkkLJR2fsa8hkq6TtFbSZkl/kdSX5DsblfFf+6jMqjxJ49P/7s+V9Er6WXw9Y7+9Jd2Q7vN5SV9peuWRjfR9d0ga0uTzKZfUPZ3/RPoemyXdK2mf9r6P5UBE+OUXEQHwMnBSOj2W5L/i/07nHwReAQ4EugHdgYeAX5Kc/KYDG4AT0vKXATXAmWnZLwErge7p+rOAUST/mHwQqAJGpus+BtQCn0+3/SBQCQzJiOVTGWUfyTiGACZlzH8FuCVjfhawuIXjPwEoJ7lK6gn8DHiouc+nmW17AKsyYj4zPf7/SdcfCqwHjgRKgXPT/fVsbt/AaGAj8O70Mzo5nR+erv87cAswOH2/49LlxwOrm8R2GXBTOj0+/YyuAXoD04BdwAHp+u8Cc9L9jgEWNd1fk32/4fNusu5fwHkZ898Hfp3xPSwDDiD5ffoG8Fi+/wb8CicFv15/pSembUBFeoL7JdA7XfcgcHlG2bFAHdA/Y9mVwPXp9GXAExnrSoB1wDtaeO8FwKx0+mPAWkAZ658C/iMjlmyTwihgKzAgnb8d+EoLMfwOuCpjvh/JiX18xufTUlI4tpmYH+P1pPAr0gSbsX5pxsn8DfsGvgr8vkn5e0mSyUigHhjcTBzHNz2J03xSGNPksz07nV4BnJKx7lNN99dk3wFsSX9nGl6nZGz7r3RaQBlwbDp/D/DJJr8f24F98v13UOwvVx9ZU++LiEERsU9E/GdE7MhYV5YxPQrYFBFbM5atIvkP903lI6IeWJ1uh6SPZlSlVJBUUw3L2HZNpGeLjH2Pau/BRMRa4FHgDEmDgNOAP7RQfFT6Pg3bbiP573x0C+WbbttczA32Ab7YcLzpMY+l5WPaBzirSfljSBLCWJLPfnMWcbXk1Yzp7SQJsOE4Mr/nzOmWHJb+zjS87k2X3wEcJWkkSdKsBx5O1+0D/DTj2DaRJI5sPmvLoW75DsAKSuYJby0wRFL/jMQwDliTUWZsw0TaMD0GWJvWHV8DnAg8HhF1khaQnBQajJakjJPsOGD2bsZ9A8l/rd3S91vTQrm1JCerhpj7AkObHFNL1rUQ8/J0ugy4IiKuaGH7pt0Vl5FcKTRtpyE9yQ6RNCgiKtrYT3utI/melqTzY1sp26qI2KzkduEPklQT3Zzx2TR8Hi0laMsTXynYbomIMpLqkSsl9UobTT8JZD6bMEPS6ZK6AReR1F0/AfQlOXltAJD0cdIG7QwjgM+lDcNnkZxU7s4itNdIGoQz/YWkneBC4MZWtv0T8HFJ09OG5O8AT0bEy1m87+Mk7SANMZ8OHJGx/hrg05KOVKKvpH+T1L+FuG8C/l3SKZJK08/4eEljImIdSfXLLyUNTt/v2Iz9DJU0MIuYm3MrcEm639HABbu5nwZ/BD5K0sbyx4zlv07f50AASQPT79nyzEnB3opzSOqo1wJ/Br4VEfdlrL+L5L/EzcB/AKdHRE1ELAF+SHIifQ04mKSKJ9OTwGSSht8rgDMjYmMWMV0G3JBWS3wAIK0CuwOYANzZ0oZp7N9My64D9gXOzuI9iYhq4HSSNo5NJMd9Z8b6ecB5wM9JPo9ladkGVwLfSOP+Upp0ZwFfI0meZcCXef1v9j9I2jteIGnAvih9nxdIktuKdF/trXK7nKSabyVwH0kbzK42tmm426vh9ZOMdbNJvsdXI2Jhw8KI+DPwPeBmSVuAZ0mq9izP9MYqULOuSdKlwH4R8ZF8x1JIJH2GpBH6uHzHYh3DVwrW5aX3yn8SuDrfsXR2kkYq6c6jRNL+wBdJrgKtSDgpWJem5IG6MuCeiHiorfJGD+A3JLfx/oukCvCXeY3IOpSrj8zMrJGvFMzMrFHBPacwbNiwGD9+fL7DMDMrKPPnzy+PiOFtlSu4pDB+/HjmzZuX7zDMzAqKpFVtl3L1kZmZZXBSMDOzRk4KZmbWyEnBzMwaOSmYmVmjnCUFSddKWi/p2RbWS9L/Khn6cJGkw3IVi5mZZSeXVwrXA6e2sv40kt4TJwPnk4xMZWZmeZSz5xQi4iFJ41spMgu4MR104wlJgySNTPuKN7MCUl8f1NYH9ZH8rKsLauvrqYugvp70Z1BXH9Slwz7W1UNduk3ySuYjnW5cXv/6dDQup7EcvF4+Mn4GybZBOuxwUjRZD6+XaZiB15e/oUyioUughp6BgsiYbn45Gdtmlm26n8z5zDJNV5x4wF5MGzuoPV9Nu+Xz4bXRvHGov9XpsjclBUnnk1xNMG7cuA4Jzqwzqq2rZ3tNHTur69hZU8/O2jp2VNexs6aOnbX1yc+aOnal63bV1FNdV8+u2nqq01dNXTqd/tyVLqupq6e2LqipT3/W1VNbH9TW1VOTnuRr6pL5hpN7XZoM3IVabikdk3DEgF5dOilkLSKuJu32eObMmf71s4Kzq7aOLTtq2bKzhi07atiys5YtO2qo3FGTLqtl264aqnbVUbWrlu3VdVRV17J9V/qzOlm+q7Z+t2PoUVpC91LRo1vJ66/SEnp0K6VHqeheWkK3UtGveze6lYhuafluJcny7g0/S0soLRHdSpTxs4TSEigtKWlcXloiSkpEqURpCZQoY7mUzpMxLSQa10u8oZwkRLJeJOszyyTTr5eTlMynZQFKShrWJctLBDQp07BtZrmGgWKl19e/XrZhu9f3QZPlmdvSZPs3lM3cQZ7kMyms4Y3jv44hu7FwzfIqIti6q5aN26rZVLWL8m3VbKqqZuO2XWysqk6XV1O+bRebqqqp3FHT5sm8e6no36s7fXuW0rdHN/r0KKVfz26M6N8zme9ZSt+e3RrX9ere8CqhV7eM6fRnz4xlDSf/znDCsc4vn0lhNnCBpJuBI4FKtydYvkUEW3bWsq5yB+sqd7KuYufr05U70vmd7Kipa3b7fj27MbRfD4b07cGYwX2YNmYQg/p0Z0Dv7gzo1S352bs7A3p1Z2Dvbgzolcz37OaTtnUOOUsKkv4EHA8Mk7Qa+BbQHSAifk0yCPu7Scaq3Q58PFexmGWKCMq3VbOyvIqV5dtYUV7Fyg1VrCyvYk3FDrZXv/GEXyIY0b8XIwf14oCRA3jnlBHsPaBX48l/WL+eDOmbTPfqXpqnozLbM3J599E5bawP4LO5en+zuvpgxYZtPP/q1vSkv42V5VWsKK9i687axnI9SkvYZ2gfxg/ryzGThzFqYG9GDurFyIG9GDmwNyP696RbqZ/ztOJQEA3NZm2pqw+Wb9jG4tWVLF5TybNrKlmybssb/usfPag3E4b15X3TRzNxeF8mDOvLxGH9GD24N6UlrroxAycFK0ARSQJYUJac/BevqWTJ2i2N9fy9u5cyddQAPjBzLAeNHsjUkQOYMKwvvXu4asesLU4KVhDWVe7g0WUbeXRZOY8sK2fD1l0A9OlRyoGjBnD2EWM5ePRADh49kInD+/k/f7Pd5KRgnVLljhqeWJEkgUeXlbN8QxUAQ/v24OhJwzh60lBm7DOYCcOcAMz2JCcF6xQigsVrKvnnc6/xyLJyFq2uoD6SqqAjJw7hnCPGcfSkYey/V39KnATMcsZJwfJqZXkVdy1Yw+wFa1lRXkVpiZg+dhAXvHMSR08axqHjBtOjm+/8MesoTgrW4dZv3clfF65j9oI1LFxdiQRvmzCU/3fcRE49cCQD+3TPd4hmRctJwTrE1p01/OPZV7lrwVoeW15OfcCBowbw9XcfwHumjWTkwN75DtHMcFKwHFu0uoKrH1rBP5e8RnVtPeOG9OGz75zErOmjmDSif77DM7MmnBRsj4sIHl++kV8+uJxHlpXTv1c3zjl8LLMOHc2hYwe5jx+zTsxJwfaY+vrgn0te41dzlrOwrILh/Xty8WlT+PCR4+jfy+0EZoXAScHespq6eu5asJZfz1nOsvXbGDekD1e8/yDOOGyMO4gzKzBOCrbbdlTXcfPcV7jmoRWsrdzJlL3787/nHMq7D9rbHciZFSgnBWu3uvrgpidW8dP7X2JTVTWHjx/MFe8/mOP3H+72ArMC56Rg7bJk7RYu+fNiFpZVcPSkoVx00n4cPn5IvsMysz3EScGysr26lp/e9xK/fWQlg/t056dnT+e900b5ysCsi3FSsDY9sHQ93/zLs6zevIOzDx/LxadNYVCfHvkOy8xywEnBWrR+604u/+sS/rZoHfsO78st57+NIycOzXdYZpZDTgr2JvX1wc1zy/juPc+zs6aez5+0H58+fiI9u/n2UrOuzknB3uCl17bytT8vZu7Lm3nbxCFc8f6D2Xd4v3yHZWYdxEnBGv114Vq+dNtCevco5aozD+GsGWPckGxWZJwUjIjgJ/e9xE/vf4nDxw/mlx+ewfD+PfMdlpnlgZNCkdtZU8cXb1vI3xet48wZY7ji/Qe57cCsiDkpFLH1W3Zy3o3zWLSmkktOm8L5x050dZFZkXNSKFLPrqnkUzfMY8vOGn7zkRm868C98x2SmXUCTgpF6B/Pvsrnb1nA4D7due3TR3HgqIH5DsnMOgknhSISEfxqznKu+sdSpo8dxNUfncGI/r3yHZaZdSJZJQVJxwCTI+I6ScOBfhGxMreh2Z60q7aOS+5czJ1Pr+G900Zx1ZmHeKwDM3uTNpOCpG8BM4H9geuA7sBNwNG5Dc32lE1V1Zx/4zzmrdrMF07ej/86YZIblM2sWdlcKbwfOBR4GiAi1kryiOsFYtuuWs699ilefG0rP//QobznkFH5DsnMOrFskkJ1RISkAJDUN8cx2R5SXVvPZ26az5J1W7jmozM4Ycpe+Q7JzDq5bMZMvFXSb4BBks4D7gOuyWbnkk6VtFTSMkkXN7N+nKQHJD0jaZGkd7cvfGtJRHDxHYt4+KVyrjz9YCcEM8tKm1cKEfEDSScDW0jaFS6NiP9raztJpcAvgJOB1cBcSbMjYklGsW8At0bEryRNBe4Gxrf/MKyp7/1jKXc+s4YvnrwfH5g5Nt/hmFmByKah+QvALdkkgiaOAJZFxIp0PzcDs4DMpBDAgHR6ILC2ne9hzbj+0ZX8es5yPnzkOC44YVK+wzGzApJN9VF/4J+SHpZ0gaRs6yFGA2UZ86vTZZkuAz4iaTXJVcJ/NbcjSedLmidp3oYNG7J8++L090Xr+PbflvCuqXtx+ayDfJeRmbVLm0khIr4dEQcCnwVGAnMk3beH3v8c4PqIGAO8G/i9pDfFFBFXR8TMiJg5fPjwPfTWXc8TKzby+VsWMGPcYP73nEMpLXFCMLP2yeZKocF64FVgIzAii/JrgMzK7DHpskyfBG4FiIjHgV7AsHbEZKkXXt3CeTfOY9zQPvz23Jl+MM3MdkubSUHSf0p6ELgfGAqcFxGHZLHvucBkSRMk9QDOBmY3KfMKcGL6PgeQJAXXD7XT2oodfOzaufTpUcoNnziCQX165DskMytQ2TynMBa4KCIWtGfHEVEr6QLgXqAUuDYinpN0OTAvImYDXwSukfR5kkbnj0VEtO8QilvF9mrOvfYpqnbVcttnjmL0oN75DsnMCliLSUHSCRHxr4i4RNKEJutOj4g729p5RNxN0oCcuezSjOkluLuM3bazpo7zbpzHqo3bueETRzBl7wFtb2Rm1orWqo9+kDF9R5N138hBLNYOEcHnb1nAvFWb+dEHp3HUvkPzHZKZdQGtJQW1MN3cvHWwW+aWcc+zr3LJaVPcn5GZ7TGtJYVoYbq5eetAqzdv53/+/jxv33conzpmYr7DMbMupLWG5omSZpNcFTRMk85PaHkzy6WI4Kt3LCIi+N4Zh1DiZxHMbA9qLSnMypj+QZN1Teetg/zhyVd4dNlGrnj/QYwd0iff4ZhZF9NiUoiIOR0ZiLWtbNN2vnP38xwzaRgfOmJcvsMxsy6oPU80Wx7V1wdfuX0RJRLfO/MQ92lkZjnhpFAgbnpyFY+v2Mg333OAH1Azs5xxUigAqzZWceXdL3DcfsM9NoKZ5VQ24yn8lTffgloJzAN+ExE7cxGYJerrgy/fvohupeK7ZxzsaiMzy6lsrhRWANtIhuC8hmQEtq3AfmQ5LKftvhsef5mnVm7i0vdMZeRAVxuZWW5l0yHe2yPi8Iz5v0qaGxGHS3ouV4EZrCyv4nv/eIETpozgzBlj8h2OmRWBbK4U+klqvP8xne6XzlbnJCqjrj748m0L6VFawpWnu9rIzDpGNlcKXwQekbSc159m/k9JfYEbchlcMbvu0ZXMW7WZH39wGnsN6JXvcMysSLSZFCLibkmTgSnpoqUZjcs/yVlkRWz5hm18/96lnHTAXrxvetNhrc3MciebKwWAGcD4tPw0SUTEjTmLqojV1Qdfum0hvXuU8p3TD3K1kZl1qGxuSf09sC+wAKhLFwfgpJADv3/8ZZ55pYKfnj2dEf1dbWRmHSubK4WZwFQPk5l7O6rr+PkDyzlq4lDeO81jJJhZx8vm7qNngb1zHYjBH55cRfm2XXzhXfu52sjM8iKbK4VhwBJJTwG7GhZGxHtzFlUR2l5dy6/nLOeYScM4fPyQfIdjZkUqm6RwWa6DMLjpiVWUb6vmopMm5zsUMyti2dyS6nEVcmx7dS2/mbOCd0wexkxfJZhZHrWYFCQ9EhHHSNrKGzvEExARMSDn0RWJGx9fxcaqai46ab98h2JmRa61kdeOSX/277hwik/VrlqufmgFx+43nBn7DM53OGZW5Nq8+yh9TqHNZbZ7bnx8FZuqqvm82xLMrBPI5pbUAzNnJHUjecLZ3qJtu2q5+qHlHL//cA4d56sEM8u/FpOCpEvS9oRDJG1JX1uB14C7OizCLuyGx15m8/YatyWYWafRYlKIiCvT9oTvR8SA9NU/IoZGxCUdGGOXtHVnDdc8vIITpoxg+thB+Q7HzAzIrvroKUkDG2YkDZL0vhzGVBRueOxlKrbXcOGJbksws84jm6TwrYiobJiJiArgW7kLqetLrhJWcuKUEUzzVYKZdSLZJIXmymTV5bakUyUtlbRM0sUtlPmApCWSnpP0x2z2W+iuf/RlKne4LcHMOp9sTu7zJP0I+EU6/1lgflsbSSpNtzkZWA3MlTQ7IpZklJkMXAIcHRGbJY1o7wEUmi1pW8JJB+zFwWMGtr2BmVkHyuZK4b9IxmK+BbgZ2EmSGNpyBLAsIlZERHW67awmZc4DfhERmwEiYn22gReq6x55mS07a93HkZl1Stn0fVQFXCypbzqdrdFAWcb8auDIJmX2A5D0KFAKXBYR/2i6I0nnA+cDjBs3rh0hdC6VO2r47SMreNfUvThotK8SzKzzyeaJ5rdLWgI8n85Pk/TLPfT+3YDJwPHAOcA1kt7U8hoRV0fEzIiYOXz48D301h3v2kdWsnVnLRf6KsHMOqlsqo9+DJwCbASIiIXAsVlstwYYmzE/Jl2WaTUwOyJqImIl8CJJkuhyKnfUcO2jKznlwL04cJSvEsysc8omKRARZU0W1TVb8I3mApMlTZDUAzgbmN2kzF9IrhKQNIykOmlFNjEVmt+lVwm+48jMOrNskkKZpLcDIam7pC+RViW1JiJqgQuAe9Pyt0bEc5Iul9Qwatu9wMa0euoB4MsRsXG3jqQT21Fdx3WPruS0g/bmgJHucdzMOq9sbkn9NPBTkobjNcA/gf/MZucRcTdwd5Nll2ZMB/CF9NVl3fPsOrburOVjbx+f71DMzFqVTVLYPyI+nLlA0tHAo7kJqeu5ff5qxg3pwxETPKqamXVu2VQf/SzLZdaMsk3beWz5Rs6cMQZJ+Q7HzKxVrQ3HeRTwdmC4pMzqnQEkzxRYFu58eg0SnDFjTL5DMTNrU2vVRz2AfmmZzCE5twBn5jKorqK+Prj96TKO3ncYowf1znc4ZmZtam2M5jnAHEnXR8QqSX0iYnsHxlbwnly5ibJNO/jiyfvnOxQzs6xk06YwKr1l9AXY4080d2m3z19N/57dOOXAvfMdiplZVrJJCj9h955oLmrbdtVy9+J1vGfaKHr3cBOMmRWGXD7RXNTuXrSOHTV1nOkGZjMrINk8p/CGJ5qBC8niieZid/v81Uwc3pfDxnlkNTMrHNlcKXyaZPyEhieap5PdeApF6+XyKp56eZOfTTCzgpPNeArlwIfbKmevu33+akoEZxzmqiMzKyytPbz2MyBaWh8Rn8tJRAWurj644+nVHLvfcPYa0Cvf4ZiZtUtr1UfzSMZi7gUcBryUvqaTPNhmzXhseTnrKne6gdnMClJrD6/dACDpM8AxaVfYSPo18HDHhFd4bp+/moG9u3PSAXvlOxQzs3bLpqF5MEl/Rw36pcusicodNfzj2Vd577RR9OruZxPMrPBkc0vqd4FnJD0AiOTBtctyGVSh+tuiteyqreesma46MrPClM3dR9dJugc4Ml301Yh4NbdhFabb569m/736c/Boj8FsZoUpmysF0iRwV45jKWjL1m/lmVcq+Pq7D/CzCWZWsLLq5sLadtv81ZSWiPcdOjrfoZiZ7bYWk4KkCR0ZSCGrravnz0+v4Z37j2B4/575DsfMbLe1dqVwO4Ck+zsoloL18EvlrN+6y88mmFnBa61NoUTS14D9mgzHCUBE/Ch3YRWW2+aXMaRvD06YMiLfoZiZvSWtXSmcTdJFdsNwnE1fBmyuqua+JeuZNX0UPbq5icbMCltrTzQvBb4naVFE3NOBMRWU2QvXUl1Xz1kzxuY7FDOztyybf20fk/QjSfPS1w8l+Ub81O3zV3PgqAFMHTWg7cJmZp1cNknhWmAr8IH0tQW4LpdBFYoXXt3C4jWVbmA2sy4jm4fX9o2IMzLmvy1pQa4CKiSzF6yltETMmu5nE8ysa8jmSmGHpGMaZiQdDezIXUiFY86LG5ixz2CG9HVP4mbWNWRzpfBp4MaMdoTNwLm5C6kwrN+6k+fWbuHLp+yf71DMzPaYbDrEWwhMkzQgnd+S86gKwEMvlgNw/P7D8xyJmdmek1WHeOBk0NSDS9czvH9Ppo70XUdm1nXk9GkrSadKWippmaSLWyl3hqSQNDOX8ewpdfXBwy+Vc9x+w90jqpl1KTlLCpJKgV8ApwFTgXMkTW2mXH/gQuDJXMWypy0oq6ByRw3H7eeqIzPrWtpMCpLmS/qspPYOwXkEsCwiVkRENXAzMKuZcv8NfA/Y2c79582cFzdQInjH5GH5DsXMbI/K5krhg8AoYK6kmyWdouzqTEYDZRnzq9NljSQdBoyNiL+3tiNJ5zc8Ub1hw4Ys3jq35ixdz/SxgxjUx7eimlnX0mZSiIhlEfF1YD/gjyRPOK+S9G1JQ3b3jSWVAD8CvphFDFdHxMyImDl8eH6rbDZu28WiNZUcv797RDWzrierNgVJhwA/BL4P3AGcRdLdxb9a2WwNkNlL3Jh0WYP+wEHAg5JeBt4GzO7sjc0Pv1ROBG5PMLMuqc1bUiXNByqA3wEXR8SudNWT6dPNLZkLTE5HcFtD0hX3hxpWRkQl0FgpL+lB4EsRMa+9B9GR5ry4gSF9e3DwaPcJaGZdTzbPKZwVESsyF0iaEBErI+L0ljaKiFpJFwD3AqXAtRHxnKTLgXkRMfstRZ4H9fXBQy9u4NjJwygp8a2oZtb1ZJMUbgcOa2bZjLY2jIi7gbubLLu0hbLHZxFLXj27tpKNVdVuTzCzLqvFpCBpCnAgMFBS5hXBAKBXrgPrjB5cugH5VlQz68Jau1LYH3gPMAj494zlW4HzchlUZzXnxQ0cMnogQ/v1zHcoZmY50dpwnHcBd0k6KiIe78CYOqWK7dU888pmLnjnpHyHYmaWM61VH30lIq4CPiTpnKbrI+JzOY2sk3lkWTn1Ace5PcHMurDWqo+eT3926ltEO8qDSzcwsHd3po8dlO9QzMxyprXqo7+mP2/ouHA6p4hgzosbeMfkYZT6VlQz68Jaqz76KxAtrY+I9+Ykok5oybotbNi6y08xm1mX11r10Q86LIpObs6LSSd8Tgpm1tW1Vn00p2FaUg9gCsmVw9K0K+yi8eDSDUwdOYARA4ry8QwzKyLZjKfwb8By4H+BnwPLJJ2W68A6iy07a3h61WaO81jMZlYEsunm4ofAOyNiGYCkfYG/A/fkMrDO4rFl5dTWB8e76sjMikA2XWdvbUgIqRUkTzUXhTkvbqB/z24ctk97B54zMys8rd191NDf0TxJdwO3krQpnEXSLXaXFxE8uHQDR08aRvfSnA1nbWbWabRWfZTZ39FrwHHp9Aagd84i6kReWr+NdZU7+dyJrjoys+LQ2t1HH+/IQDqjB5euB3wrqpkVj2xGXusFfJKkG+3GezIj4hM5jKtTmPPiBvbbqx+jBhXFhZGZWVYNzb8H9gZOAeaQjLXc5Ru6eLeoAAAPjUlEQVSaq3bVMnflZg+oY2ZFJZukMCkivglUpf0g/RtwZG7Dyr/Hl2+kuq7eVUdmVlSySQo16c8KSQcBA4Eu/+/znBc30KdHKTPH+1ZUMyse2Ty8drWkwcA3gdlAv3S6y4oIHnxxPW/fdyg9u5XmOxwzsw7TZlKIiN+mk3OAibkNp3NYWV5F2aYdnH/svvkOxcysQ2XT99FQST+T9LSk+ZJ+ImloRwSXLw8uTXpFddcWZlZssmlTuBlYD5wBnAmUA7fkMqh8m/PiBiYO78vYIX3yHYqZWYfKJimMjIj/joiV6et/gL1yHVi+1NTV88SKjRw72VcJZlZ8skkK/5R0tqSS9PUB4N5cB5YvL6zbyq7aet91ZGZFqbUO8baSdIAn4CLgpnRVCbAN+FLOo8uDBasrAJg2ZlCeIzEz63it9X3UvyMD6SwWllUwtG8Pxgx21xZmVnyyeU4BSe8Fjk1nH4yIv+UupPxaUFbB9LGDkJTvUMzMOlw2t6R+F7gQWJK+LpR0Za4Dy4ctO2tYvmEb08a66sjMilM2VwrvBqZHRD2ApBuAZ4BLchlYPjy7upIInBTMrGhlO5xY5llyYLY7l3SqpKWSlkm6uJn1X5C0RNIiSfdL2ifbfefCM2UNjcxZH6KZWZeSzZXClcAzkh4guRPpWOBNJ/imJJUCvwBOBlYDcyXNjoglGcWeAWZGxHZJnwGuAj7YzmPYYxaWVTBhWF8G9emRrxDMzPKq1aSgpLX1EeBtwOHp4q9GxKtZ7PsIYFlErEj3dTMwi6RdAoCIeCCj/BPAR7IPfc9buLqCoyZ26R48zMxa1WpSiIiQdHdEHEzSQ2p7jAbKMuZX0/o4DJ8E7mluhaTzgfMBxo0b184wsrOucgevbdnFdLcnmFkRy6ZN4WlJh7ddbPdJ+ggwE/h+c+sj4uqImBkRM4cPz033Ewsb2hOcFMysiGXTpnAk8BFJLwNVJO0KERGHtLHdGmBsxvyYdNkbSDoJ+DpwXETsyiboXHimrILupeKAkQPyFYKZWd5lkxRO2c19zwUmS5pAkgzOBj6UWUDSocBvgFMjYv1uvs8esbCsgqkjB9CruwfVMbPi1VrfR72ATwOTgMXA7yKiNtsdR0StpAtIOs8rBa6NiOckXQ7Mi4jZJNVF/YDb0ieIX4mI9+720eymuvpg8epKzpgxpqPf2sysU2ntSuEGkvGZHwZOA6aSPNmctYi4G7i7ybJLM6ZPas/+cmXZ+m1UVde5EzwzK3qtJYWp6V1HSPod8FTHhNTxGhqZp49zUjCz4tba3Uc1DRPtqTYqRAtWV9C/VzcmDO2b71DMzPKqtSuFaZK2pNMCeqfzDXcfdZnbdBa8kvSMWlLinlHNrLi1Np5CUdyGs6O6jqWvbeUzU/bNdyhmZnmXbYd4XdZzayupqw8/tGZmhpMCCxqfZHbPqGZmTgplFYwe1JsR/XvlOxQzs7wr+qSwcHWFrxLMzFJFnRQ2bttF2aYd7hnVzCxV1Elh4eqGkdacFMzMoMiTwoKySkoEB4129ZGZGRR9Uqhgv73607dnNp3Fmpl1fUWbFCKChWUVbk8wM8tQtElh1cbtVO6o8UNrZmYZijYpNDy05isFM7PXFXVS6N29lMkj+uU7FDOzTqOok8LBowfSrbRoPwIzszcpyjNidW09S9Zu8aA6ZmZNFGVSeOHVLVTX1fuhNTOzJooyKbhnVDOz5hVtUhjWryejB/XOdyhmZp1KUSaF5KG1gUgeftPMLFPRJYXKHTUs31Dl5xPMzJpRdElh8epKAD/JbGbWjKJLCg3dZR/iO4/MzN6k6JLCM69UMHF4Xwb27p7vUMzMOp2iSgoRwYKyCqb7KsHMrFlFlRTWVe6kfNsutyeYmbWgqJKCe0Y1M2tdUSWFhWUV9CgtYcrI/vkOxcysUyqqpLCgrIIDRg2gZ7fSfIdiZtYp5TQpSDpV0lJJyyRd3Mz6npJuSdc/KWl8rmKpqw8Wr6nkUFcdmZm1KGdJQVIp8AvgNGAqcI6kqU2KfRLYHBGTgB8D38tVPC+t38r26jp3gmdm1opcXikcASyLiBURUQ3cDMxqUmYWcEM6fTtwonLUIdGCV9KeUX07qplZi3KZFEYDZRnzq9NlzZaJiFqgEhjadEeSzpc0T9K8DRs27FYwg/v24OSpezFhWN/d2t7MrBh0y3cA2YiIq4GrAWbOnBm7s49TDtybUw7ce4/GZWbW1eTySmENMDZjfky6rNkykroBA4GNOYzJzMxakcukMBeYLGmCpB7A2cDsJmVmA+em02cC/4qI3boSMDOzty5n1UcRUSvpAuBeoBS4NiKek3Q5MC8iZgO/A34vaRmwiSRxmJlZnuS0TSEi7gbubrLs0ozpncBZuYzBzMyyV1RPNJuZWeucFMzMrJGTgpmZNXJSMDOzRiq0O0AlbQBW7ebmw4DyPRhOZ9DVjqmrHQ90vWPqascDXe+YmjuefSJieFsbFlxSeCskzYuImfmOY0/qasfU1Y4Hut4xdbXjga53TG/leFx9ZGZmjZwUzMysUbElhavzHUAOdLVj6mrHA13vmLra8UDXO6bdPp6ialMwM7PWFduVgpmZtcJJwczMGhVNUpB0qqSlkpZJujjf8bxVkl6WtFjSAknz8h3P7pB0raT1kp7NWDZE0v9Jein9OTifMbZHC8dzmaQ16fe0QNK78xlje0kaK+kBSUskPSfpwnR5QX5PrRxPwX5PknpJekrSwvSYvp0unyDpyfScd0s6hEHb+yuGNgVJpcCLwMkkw4LOBc6JiCV5DewtkPQyMDMiCvaBG0nHAtuAGyPioHTZVcCmiPhumrwHR8RX8xlntlo4nsuAbRHxg3zGtrskjQRGRsTTkvoD84H3AR+jAL+nVo7nAxTo95SOa983IrZJ6g48AlwIfAG4MyJulvRrYGFE/Kqt/RXLlcIRwLKIWBER1cDNwKw8x1T0IuIhknE0Ms0CbkinbyD5gy0ILRxPQYuIdRHxdDq9FXieZGz1gvyeWjmeghWJbels9/QVwAnA7enyrL+jYkkKo4GyjPnVFPgvAsmX/k9J8yWdn+9g9qC9ImJdOv0qsFc+g9lDLpC0KK1eKohqluZIGg8cCjxJF/iemhwPFPD3JKlU0gJgPfB/wHKgIiJq0yJZn/OKJSl0RcdExGHAacBn06qLLiUdmrXQ6zd/BewLTAfWAT/Mbzi7R1I/4A7goojYkrmuEL+nZo6noL+niKiLiOnAGJKakSm7u69iSQprgLEZ82PSZQUrItakP9cDfyb5RegKXkvrfRvqf9fnOZ63JCJeS/9g64FrKMDvKa2nvgP4Q0TcmS4u2O+puePpCt8TQERUAA8ARwGDJDWMrpn1Oa9YksJcYHLaGt+DZCzo2XmOabdJ6ps2kiGpL/Au4NnWtyoYs4Fz0+lzgbvyGMtb1nDiTL2fAvue0kbM3wHPR8SPMlYV5PfU0vEU8vckabikQel0b5Ibap4nSQ5npsWy/o6K4u4jgPQWs58ApcC1EXFFnkPabZImklwdQDLO9h8L8Xgk/Qk4nqSb39eAbwF/AW4FxpF0kf6BiCiIxtsWjud4kiqJAF4G/l9GXXynJ+kY4GFgMVCfLv4aST18wX1PrRzPORTo9yTpEJKG5FKSf/RvjYjL0/PEzcAQ4BngIxGxq839FUtSMDOzthVL9ZGZmWXBScHMzBo5KZiZWSMnBTMza+SkYGZmjZwUrENJulLSOyW9T9Il7dx2eNrr4zOS3tFk3cuShu3hWLe1sPxySSel0xdJ6rMn37ezknS8pL/lOw7LLScF62hHAk8AxwEPtXPbE4HFEXFoRDy8xyPLUkRcGhH3pbMXAQWbFJTwecAa+ZfBOoSk70taBBwOPA58CviVpEubKTte0r/SzsnulzRO0nTgKmBW2t997xbep7ekeySdl85/JO1rfoGk36Qdh31C0k8ytjlP0o9b2N+P0z7q75c0PF12vaQzJX0OGAU8oKSP/tJ03bNKxrr4fDP720vSn5X0fb9Q0tvT5V9It3tW0kUZn8ML6T5flPQHSSdJelTJOAZHpOUuk/R7SY+nyxuOvV8a99NpPLMy9rtU0o0kT+6OlfSudPunJd2W9g3UMA7JC5KeBk5v84u2whcRfvnVIS+ShPAzkq59H22l3F+Bc9PpTwB/Sac/Bvy8hW1eBsYD9wEfTZcdkO6rezr/S+CjQD+SXiQblj8GHNzMPgP4cDp9acN7A9cDZ2a877B0egbwfxnbD2pmn7eQdMIGyROoA9PtFgN909ieI+m9czxQCxxM8g/cfOBaQCRdVzd8LpcBC4HeJE9Tl5Ekq27AgLTMMGBZuu14kqd535ax7iGSPvkBvpoeb690X5PT7W4F/pbv3yO/cvvylYJ1pMNITl5TSPpmaclRwB/T6d8Dx2S5/7uA6yLixnT+RJIT7lwl3QqfCEyMpO/5fwHvkTSFJDksbmZ/9SQncYCbsohjBTBR0s8knQpsaabMCSQ9chJJB2yV6X7/HBFVaWx3Ag1tJisjYnEkHbU9B9wfEUGSRMZnHntE7Ihk0KUHSDp0E/Cd9ArtPpKukxu6uF4VEU+k028DpgKPpp/TucA+JN/Tyoh4KX3Pm9o4fusCurVdxOytSat+rifpqbGcpA5e6QnoqIjYsYfe6lHgVEl/TE9iAm6IiOYatH9L0ufNC8B1We6/1T5hImKzpGnAKcCnSUbz+kS2wbcgs6+a+oz5et7499s0tgA+DAwHZkREjZLR+nql66syyorkCueczB2k35sVGV8pWM5FxIJI+np/keQ/0n8Bp0TE9BYSwmMkPdlCcmLLtlH5UmAz8It0/n7gTEkjoHFc4X3SmJ4k6U79Q8CfWthfCa/3MvkhkmEOm9oKNPRYOwwoiYg7gG+QXBk1dT/wmbR8qaSB6fG9T1IfJb3evr8dx9xglpKxeoeSdMI3l6Rqan2aEN5J8t9/c54AjpY0KY2rr6T9SBLmeEn7puXOaWF760KcFKxDpI20m9NqkCnR+vjY/wV8PK32+A+S8WazdSHQW9JV6Xt8g2SEukUkI1JldpF8K0nbxuYW9lUFHCHpWZJqn8ubKXM18A9JD5BUzzyYXgHdBDR3hXIh8E5Ji0naCKZGMjzk9cBTJL2P/jYinmnHMQMsIqk2egL474hYC/wBmJm+10dJTvJvEhEbSNpr/pR+To+TfEc7gfOBv6cNzQUzZoLtPveSakUrvef+xxFxf75jeSskXUaBDjpvnY+vFKzoSBok6UVgR6EnBLM9zVcKZmbWyFcKZmbWyEnBzMwaOSmYmVkjJwUzM2vkpGBmZo3+P7NQYl8Ov8lPAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzt3XecXVW5//HPd2bSe4VUkpCEUBNIABGkI+V6DVIU1Cs2+OmVq9jhqojciwX7tYPSRKWJEhVERQjSSSAFAoEUwkwSSJ1JMinTnt8fe89wGKacCTlz5sz5vl+v85pd1t7n2efM7Gf2WnuvpYjAzMwMoCTfAZiZWdfhpGBmZk2cFMzMrImTgpmZNXFSMDOzJk4KZmbWxEnBckLSFZJu3s1tPyjpoTbWPyDpo+n0+yT9bXfj7GBcR0t6UdI2SWdmUf4GSf/bGbG1E8d/S/plvuOwwuCkYE0kvSRpR3rSe1XS9ZL65zuutkTEbyLi7Y3zkkLS5By93ZXAjyOif0T8cU/uOP3sT94D+zleUkXmsoj4ekR89M3uu5X3C0nV6e9M4+sLuXgv6xxOCtbcv0dEf+Aw4HDgy80LKFGMvzv7AM/mO4guaHqaKBtfV+c7INt9xfiHbVmIiNXAPcBB0FRlc5Wkh4HtwCRJoyXNkbRJ0jJJFzbbTW9Jt0raKukpSdMbV0i6VNLydN0SSe9qtq0k/UhSlaTnJZ3UUpyZVU2SHkwXL0z/Y32PpGck/XtG+R6SNkia0cr+LkyPZVN6bKPT5cuBScCf0n33amHbQ9Pj3CrpVqB3s/XvkLRAUqWkRyQdki7/NTA+Y99fSJe/JS1XKWmhpOMz9jU0vZJbI2mzpD9K6kfynY3O+K99dGZVnqQJ6X/3F0h6Of0svpSx3z6Sbkz3+ZykLzS/8shG+r47JA1t9vlskNQjnf9w+h6bJd0raZ+Ovo/lQET45RcRAfAScHI6PY7kv+L/SecfAF4GDgTKgB7AXOCnJCe/GcB64KS0/BVALXBOWvZzwEqgR7r+XGA0yT8m7wGqgVHpug8CdcCn023fA1QBQzNi+WhG2YcyjiGAyRnzXwBuzZifDSxu5fhPBDaQXCX1An4EPNjS59PCtj2BVRkxn5Me//+m6w8D1gFHAqXABen+erW0b2AMsBE4I/2MTknnR6Tr/wLcCgxJ3++4dPnxQEWz2K4Abk6nJ6Sf0bVAH2A6sAvYP13/zfR7HQKMBRY131+zfb/u82627p/AhRnz3wZ+nk6fCSwD9if5ffoy8Ei+/wb8CicFv157pSembUBleoL7KdAnXfcAcGVG2XFAPTAgY9k3gBvS6SuAxzLWlQBrgbe18t4LgNnp9AeBNYAy1j8B/EdGLNkmhdHAVmBgOn8H8IVWYvgVcHXGfH+SE/uEjM+ntaRwbAsxP8JrSeFnpAk2Y/3SjJP56/YNfBH4dbPy95Ikk1FAAzCkhTiOb34Sp+WkMLbZZ3teOr0CODVj3Ueb76/ZvgPYkv7ONL5Ozdj2n+m0gHLg2HT+HuAjzX4/tgP75PvvoNhfrj6y5s6MiMERsU9E/GdE7MhYV54xPRrYFBFbM5atIvkP9w3lI6IBqEi3Q9IHMqpSKkmqqYZnbLs60rNFxr5Hd/RgImIN8DBwtqTBwOnAb1opPjp9n8Ztt5H8dz6mlfLNt20p5kb7AJ9tPN70mMfR+jHtA5zbrPwxJAlhHMlnvzmLuFrzSsb0dpIE2Hgcmd9z5nRrDkt/Zxpf96bL7wCOSqvgjiVJIP9K1+0D/DDj2DaRJI5sPmvLobJ8B2AFJfOEtwYYKmlARmIYD6zOKDOucSJtmB4LrEnrjq8FTgIejYh6SQtITgqNxkhSxkl2PDBnN+O+keS/1rL0/Va3Um4NycmqMeZ+wLBmx9Sata3EvDydLgeuioirWtm+eXfF5SRXCs3baZA0iuSzHxwRle3sp6PWknxPS9L5cW2UbVNEVCq5XfjdJNVEv8v4bBo/j9YStOWJrxRst0REOUn1yDck9U4bTT/C6/8LnynpLEllwCUkddePAf1ITl7rASR9iLRBO8NI4JNpw/C5JCeVu7MI7VWSBuFMfySp0/8UcFMb2/4W+JCkGWlD8teBxyPipSze91GSdpBPSiqTdBZwRMb6a4GPSTpSiX6S/k3SgFbivhn4d0mnSipNP+PjJY2NiLUk1S8/lTQk/YyOzdjPMEmDsoi5JbcBl6X7HQNcvJv7afRb4APA2el0o5+n73MggKRB6fdseeakYG/G+SR11GuAPwBfjYi/Z6y/i6SReDPwH8BZEVEbEUuA75KcSF8FDiap4sn0ODCFpOH3KuCciNiYRUxXADem1RLvBkirwH4PTATubG3DiLgP+Epadi2wL3BeFu9JRNQAZ5G0cWwmOe47M9bPAy4EfpyuX5aWbfQN4Mtp3J9Lk+5s4L9Jkmc58Hle+5v9D5L2judJGrAvSd/neeB3wIp0Xx2tcruSpJpvJfAPkiqgXe1s03i3V+PrBxnr5pB8j69GxMLGhRHxB+BbwC2StgDPkFTtWZ7p9VWgZt2TpMuBqRHx/nzHUkgkfZykEfq4fMdincNXCtbtpffKfwS4Jt+xdHWSRinpzqNE0n7AZ0muAq1IOClYt6bkgbpy4J6IeLC98kZP4Bckt/H+k6QK8Kd5jcg6lauPzMysia8UzMysScE9pzB8+PCYMGFCvsMwMyso8+fP3xARI9orV3BJYcKECcybNy/fYZiZFRRJq9ov5eojMzPL4KRgZmZNnBTMzKyJk4KZmTVxUjAzsyY5SwqSrpO0TtIzrayXpP9TMvThIkmH5SoWMzPLTi6vFG4ATmtj/ekkvSdOAS4iGZnKzMzyKGfPKUTEg5ImtFFkNnBTOujGY5IGSxqV9hVvZgWkoSGoawgaIvlZXx/UNTRQH0FDA+nPoL4hqE+HfaxvgPp0m+SVzEc63bS84bXpaFpOUzl4rXxk/AySbYN02OGkaLIeXivTOAOvLX9dmURjl0CNPQMFkTHd8nIyts0s23w/mfOZZZqvOGn/vZg+bnBHvpoOy+fDa2N4/VB/FemyNyQFSReRXE0wfvz4TgnOrCuqq29ge209O2vq2VnbwM66enbU1LOztp6ddQ3Jz9p6dqXrdtU2UFPfwK66BmrSV219Op3+3JUuq61voK4+qG1If9Y3UNcQ1NU3UJue5Gvrk/nGk3t9mgzchVpuKR2TcOTA3t06KaiFZS3+akXENaTdHs+aNcu/flZwdtXVs2VHHVt21rJlRy1bdtaxZUctVTtq02V1bNtVS/Wueqp31bG9pp7qmjq270p/1iTLd9U17HYMPUtL6FEqepaVvPYqLaFnWSk9S0WP0hLKSkX/HmWUlYiytHxZSbK8R+PP0hJKS0RZiTJ+llBaAqUlJU3LS0tESYkolSgtgRJlLJfSeTKmhUTTeonXlZOESNaLZH1mmWT6tXKSkvm0LEBJSeO6ZHmJgGZlGrfNLNd4tpJeW/9a2cbtXtsHzZZnbkuz7V9XNnMHeZLPpFDB68d/HUsygpdZlxYRbN1Vx8ZtNWyq3sWGbTVsqq5h47ZdbKyuSZfXsGHbLjZV11C1o7bdk3mPUjGgdw/69SqlX88y+vYspX+vMkYO6JXM9yqlX6+ypnW9ezS+SuhdljGd/uyVsazx5N8VTjjW9eUzKcwBLpZ0C3AkUOX2BMu3iGDLzjrWVu1gbdVO1lbufG26akc6v5MdtfUtbt+/VxnD+vdkaL+ejB3Sl+ljBzO4bw8G9unBwN5lyc8+PRjYuweD+pQxsHcy36vMJ23rGnKWFCT9DjgeGC6pAvgq0AMgIn5OMgj7GSRj1W4HPpSrWMwyRQQbttWwckM1KzdsY8WGalaur2blhmpWV+5ge83rT/glgpEDejNqcG/2HzWQE6aNZO+BvZtO/sP792Jov2S6d4/SPB2V2Z6Ry7uPzm9nfQCfyNX7m9U3BCvWb+O5V7amJ/1trNxQzYoN1WzdWddUrmdpCfsM68uE4f04ZspwRg/qw6jBvRk1qDejBvVh5IBelJX6OU8rDgXXdbZZS+obguXrt7G4oorFq6t4ZnUVS9Zued1//WMG92Hi8H6cOWMMk0b0Y+Lwfkwa3p8xQ/pQWuKqGzNwUrACFJEkgAXlycl/8eoqlqzZ0lTP36dHKQeMHsi7Z43joDGDOGDUQCYO70efnq7aMWuPk4IVhLVVO3h42UYeXraBh5ZtYP3WXQD07VnKgaMHct4R4zh4zCAOHjOISSP6+z9/s93kpGBdUtWOWh5bkSSBh5dtYPn6agCG9evJ0ZOHc/TkYczcZwgThzsBmO1JTgrWJUQEi1dX8bdnX+WhZRtYVFFJQyRVQUdOGsr5R4zn6MnD2W+vAZQ4CZjljJOC5dXKDdXctWA1cxasYcWGakpLxIxxg7n4hMkcPXk4h44fQs8y3/lj1lmcFKzTrdu6kz8tXMucBatZWFGFBG+ZOIz/d9wkTjtwFIP69sh3iGZFy0nBOsXWnbX89ZlXuGvBGh5ZvoGGgANHD+RLZ+zPO6aPYtSgPvkO0cxwUrAcW1RRyTUPruBvS16lpq6B8UP78okTJjN7xmgmjxyQ7/DMrBknBdvjIoJHl2/kpw8s56FlGxjQu4zzDx/H7EPHcOi4we7jx6wLc1KwPaahIfjbklf52dzlLCyvZMSAXlx6+jTed+R4BvR2O4FZIXBSsDettr6Buxas4edzl7Ns3TbGD+3LVe86iLMPG+sO4swKjJOC7bYdNfXc8uTLXPvgCtZU7WTa3gP4v/MP5YyD9nYHcmYFyknBOqy+Ibj5sVX88L4X2VRdw+EThnDVuw7m+P1GuL3ArMA5KViHLFmzhcv+sJiF5ZUcPXkYl5w8lcMnDM13WGa2hzgpWFa219Txw3+8yC8fWsmQvj344XkzeOf00b4yMOtmnBSsXfcvXcdX/vgMFZt3cN7h47j09GkM7tsz32GZWQ44KVir1m3dyZV/WsKfF61l3xH9uPWit3DkpGH5DsvMcshJwd6goSG45clyvnnPc+ysbeDTJ0/lY8dPoleZby816+6cFOx1Xnx1K//9h8U8+dJm3jJpKFe962D2HdE/32GZWSdxUrAmf1q4hs/dvpA+PUu5+pxDOHfmWDckmxUZJwUjIvjBP17kh/e9yOEThvDT981kxIBe+Q7LzPLASaHI7ayt57O3L+Qvi9ZyzsyxXPWug9x2YFbEnBSK2LotO7nwpnksWl3FZadP46JjJ7m6yKzIOSkUqWdWV/HRG+exZWctv3j/TN5+4N75DsnMugAnhSL012de4dO3LmBI3x7c/rGjOHD0oHyHZGZdhJNCEYkIfjZ3OVf/dSkzxg3mmg/MZOSA3vkOy8y6kKySgqRjgCkRcb2kEUD/iFiZ29BsT9pVV89ldy7mzqdW887po7n6nEM81oGZvUG7SUHSV4FZwH7A9UAP4Gbg6NyGZnvKpuoaLrppHvNWbeYzp0zlv06c7AZlM2tRNlcK7wIOBZ4CiIg1kjzieoHYtquOC657ghde3cqP33so7zhkdL5DMrMuLJukUBMRISkAJPXLcUy2h9TUNfDxm+ezZO0Wrv3ATE6ctle+QzKzLi6bMRNvk/QLYLCkC4F/ANdms3NJp0laKmmZpEtbWD9e0v2Snpa0SNIZHQvfWhMRXPr7RfzrxQ1846yDnRDMLCvtXilExHcknQJsIWlXuDwi/t7edpJKgZ8ApwAVwJOS5kTEkoxiXwZui4ifSToAuBuY0PHDsOa+9del3Pn0aj57ylTePWtcvsMxswKRTUPzp4Hbs0kEzRwBLIuIFel+bgFmA5lJIYCB6fQgYE0H38NacMPDK/n53OW878jxXHzi5HyHY2YFJJvqo4HAvZL+JekTkrKthxgDlGfMV6TLMl0BvF9SBclVwn+1tCNJF0maJ2ne+vXrs3z74vSXRWv52p+X8PYD9uLK2Qf5LiMz65B2k0JEfC0iDgQ+AYwG5kr6Rxb7bulsFM3mzwduiIixwBnAryW9IaaIuCYiZkXErBEjRmTx1sXpsRUb+fStC5g5fgj/d/6hlJY4IZhZx2RzpdBoHfAKsBEYmUX5CiCzMnssb6we+ghwG0BEPAr0BoZ3ICZLPf/KFi68aR7jh/XllxfM8oNpZrZb2k0Kkj4u6QHgPpIT9oURcUgW+34SmCJpoqSewHnAnGZlXgZOSt9nf5Kk4PqhDlpTuYMPXvckfXuWcuOHj2Bw3575DsnMClQ2zynsA1wSEQs6suOIqJN0MXAvUApcFxHPSroSmBcRc4DPAtemjdkBfDAimlcxWRsqt9dwwXVPUL2rjts/fhRjBvfJd0hmVsBaTQqSToyIf0bEpZImNlt3VkTc2d7OI+JukgbkzGWXZ0wvwd1l7LadtfVceNM8Vm3czo0fPoJpew9sfyMzsza0VX30nYzp3zdb9+UcxGIdEBF8+tYFzFu1me+9ZzpH7Tss3yGZWTfQVlJQK9MtzVsnu/XJcu555hUuO32a+zMysz2mraQQrUy3NG+dqGLzdv73L8/x1n2H8dFjJuU7HDPrRtpqaJ4kaQ7JVUHjNOn8xNY3s1yKCL74+0VEBN86+xBK/CyCme1BbSWF2RnT32m2rvm8dZLfPP4yDy/byFXvOohxQ/vmOxwz62ZaTQoRMbczA7H2lW/aztfvfo5jJg/nvUeMz3c4ZtYNdeSJZsujhobgC3csokTiW+cc4j6NzCwnnBQKxM2Pr+LRFRv5yjv29wNqZpYzTgoFYNXGar5x9/McN3WEx0Yws5zKZjyFP/HGW1CrgHnALyJiZy4Cs0RDQ/D5OxZRViq+efbBrjYys5zK5kphBbCNZAjOa0lGYHsVmEqWw3La7rvx0Zd4YuUmLn/HAYwa5GojM8utbDrEOzQijs2Y/5OkByPiWEnP5iowg5UbqvnWX5/nxGkjOWfm2HyHY2ZFIJsrhRGSmu5/TKcbxzyoyUlURn1D8PnbF9KztIRvnOVqIzPrHNlcKXwWeEjScl57mvk/JfUDbsxlcMXs+odXMm/VZr7/nunsNbB3vsMxsyLRblKIiLslTQGmkSSF5zMal3+Qy+CK1fL12/j2vUs5ef+9OHNG82GtzcxyJ5srBYCZwIS0/CGSiIibchZVEatvCD53+0L69Czl62cd5GojM+tU2dyS+mtgX2ABUJ8uDsBJIQd+/ehLPP1yJT88bwYjB7jayMw6VzZXCrOAAzxMZu7tqKnnx/cv56hJw3jndI+RYGadL5u7j54B9s51IAa/eXwVG7bt4jNvn+pqIzPLi2yuFIYDSyQ9AexqXBgR78xZVEVoe00dP5+7nGMmD+fwCUPzHY6ZFalsksIVuQ7C4ObHVrFhWw2XnDwl36GYWRHL5pZUj6uQY9tr6vjF3BW8bcpwZvkqwczyqNWkIOmhiDhG0lZe3yGegIiIgTmPrkjc9OgqNlbXcMnJU/MdipkVubZGXjsm/Tmg88IpPtW76rjmwRUcO3UEM/cZku9wzKzItXv3UfqcQrvLbPfc9OgqNlXX8Gm3JZhZF5DNLakHZs5IKiN5wtnepG276rjmweUcv98IDh3vqwQzy79Wk4Kky9L2hEMkbUlfW0nGUrir0yLsxm585CU2b691W4KZdRmtJoWI+EbanvDtiBiYvgZExLCIuKwTY+yWtu6s5dp/reDEaSOZMW5wvsMxMwOyqz56QtKgxhlJgyWdmcOYisKNj7xE5fZaPnWS2xLMrOvIJil8NSKqGmciohL4au5C6v6Sq4SVnDRtJNN9lWBmXUg2SaGlMll1uS3pNElLJS2TdGkrZd4taYmkZyX9Npv9FrobHn6Jqh1uSzCzriebk/s8Sd8DfkLyENt/AfPb20hSabrNKUAF8KSkORGxJKPMFOAy4OiI2Cxp5G4cQ0HZkrYlnLz/Xhw8dlD7G5iZdaJsrhT+i2Qs5luB24AdwCey2O4IYFlErIiIGuAWYHazMhcCP4mIzQARsS7bwAvV9Q+9xJadde7jyMy6pGz6PqoGLpXUPyK2dWDfY4DyjPkK4MhmZaYCSHoYKAWuiIi/Nt+RpIuAiwDGjx/fgRC6lqodtfzyoRW8/YC9OGiMrxLMrOvJ5onmt0paAixJ56dL+mkW+25pQIDmA/WUAVOA44HzgV9KekPLa0RcExGzImLWiBEjsnjrrum6h1aydWcdn/JVgpl1UdlUH30fOBXYCBARC4Fjs9iuAhiXMT8WWNNCmbsiojYiVgJLSZJEt1O1o5brHl7JqQfuxYGjfZVgZl1TNkmBiChvtqi+xYKv9yQwRdJEST2B84A5zcr8ETgBQNJwkuqkFdnEVGh+lV4l+I4jM+vKskkK5ZLeCoSknpI+BzzX3kYRUQdcDNyblr8tIp6VdKWkxlHb7gU2ptVT9wOfj4iNu3UkXdiOmnquf3glpx+0N/uPco/jZtZ1ZXNL6seAH5I0HFcAfwP+M5udR8TdwN3Nll2eMR3AZ9JXt3XPM2vZurOOD751Qr5DMTNrUzZJYb+IeF/mAklHAw/nJqTu5475FYwf2pcjJnpUNTPr2rKpPvpRlsusBeWbtvPI8o2cM3MsUks3ZJmZdR1tDcd5FPBWYISkzOqdgSTPFFgW7nxqNRKcPXNsvkMxM2tXW9VHPYH+aZnMITm3AOfkMqjuoqEhuOOpco7edzhjBvfJdzhmZu1qa4zmucBcSTdExCpJ/dKnmy1Lj6/cRPmmHXz2lP3yHYqZWVayaVMYnd4y+hx06InmonfH/AoG9Crj1AP3zncoZmZZySYp/IDde6K5qG3bVcfdi9fyjumj6dPTTTBmVhhy+URzUbt70Vp21NZzjhuYzayAZPOcwuueaAY+SRZPNBe7O+ZXMGlEPw4b75HVzKxwZHOl8DGS8RMan2ieQXbjKRStlzZU88RLm/xsgpkVnGzGU9gAvK+9cvaaO+ZXUCI4+zBXHZlZYWnr4bUf8cbxD5pExCdzElGBq28Ifv9UBcdOHcFeA3vnOxwzsw5pq/poHslYzL2Bw4AX09cM3NDcqkeWb2Bt1U43MJtZQWrr4bUbASR9EDghImrT+Z+T9JRqLbhjfgWD+vTg5P33yncoZmYdltXDa7y+m4v+6TJrpmpHLX995hXeOX00vXv42QQzKzzZ3JL6TeBpSfen88cBV+QsogL250Vr2FXXwLmzXHVkZoUpm7uPrpd0D3BkuujSiHglt2EVpjvmV7DfXgM4eIzHYDazwpTNlQJpErgrx7EUtGXrtvL0y5V86Yz9/WyCmRWsrLq5sPbdPr+C0hJx5qFj8h2KmdluazUpSJrYmYEUsrr6Bv7w1GpO2G8kIwb0ync4Zma7ra0rhTsAJN3XSbEUrH+9uIF1W3f52QQzK3httSmUSPoqMLXZcJwARMT3chdWYbl9fjlD+/XkxGkj8x2Kmdmb0taVwnnATl4bjrP5y4DN1TX8Y8k6Zs8YTc8yN9GYWWFr64nmpcC3JC2KiHs6MaaCMmfhGmrqGzh35rh8h2Jm9qZl86/tI5K+J2le+vquJN+In7pjfgUHjh7IAaMH5jsUM7M3LZukcB2wFXh3+toCXJ/LoArF869sYfHqKjcwm1m3kc3Da/tGxNkZ81+TtCBXARWSOQvWUFoiZs/wswlm1j1kc6WwQ9IxjTOSjgZ25C6kwjH3hfXM3GcIQ/v1zHcoZmZ7RDZXCh8DbspoR9gMXJC7kArDuq07eXbNFj5/6n75DsXMbI/JpkO8hcB0SQPT+S05j6oAPPjCBgCO329EniMxM9tzsuoQD5wMmntg6TpGDOjFAaN815GZdR85fdpK0mmSlkpaJunSNsqdIykkzcplPHtKfUPwrxc3cNzUEe4R1cy6lZwlBUmlwE+A04EDgPMlHdBCuQHAJ4HHcxXLnragvJKqHbUcN9VVR2bWvbSbFNIH1j4haUgH930EsCwiVkREDXALMLuFcv8DXE3SpUZBmPvCekoEb5syPN+hmJntUdlcKZxHMibzk5JukXSqsqszGQOUZ8xXpMuaSDoUGBcRf25rR5Iuanyiev369Vm8dW7NXbqOGeMGM7ivb0U1s+6l3aQQEcsi4kvAVOC3JE84vyzpa5KGtrFpS4kjmlZKJcD3gc9mEcM1ETErImaNGJHfKpuN23axaHUVx+/nHlHNrPvJqk1B0iHAd4FvA78HziHp7uKfbWxWAWT2EjcWWJMxPwA4CHhA0kvAW4A5Xb2x+V8vbiACtyeYWbfU7i2pkuYDlcCvgEsjYle66vH06ebWPAlMSUdwW01SDfXexpURUQU0VcpLegD4XETM6+hBdKa5L6xnaL+eHDzGfQKaWfeTzXMK50bEiswFkiZGxMqIOKu1jSKiTtLFwL1AKXBdRDwr6UpgXkTMeVOR50FDQ/DgC+s5dspwSkp8K6qZdT/ZJIU7gMNaWDazvQ0j4m7g7mbLLm+l7PFZxJJXz6ypYmN1jdsTzKzbajUpSJoGHAgMkpR5RTAQ6J3rwLqiB5auR74V1cy6sbauFPYD3gEMBv49Y/lW4MJcBtVVzX1hPYeMGcSw/r3yHYqZWU60NRznXcBdko6KiEc7MaYuqXJ7DU+/vJmLT5ic71DMzHKmreqjL0TE1cB7JZ3ffH1EfDKnkXUxDy3bQEPAcW5PMLNurK3qo+fSn136FtHO8sDS9Qzq04MZ4wbnOxQzs5xpq/roT+nPGzsvnK4pIpj7wnreNmU4pb4V1cy6sbaqj/5ERrcUzUXEO3MSURe0ZO0W1m/d5aeYzazba6v66DudFkUXN/eFpBM+JwUz6+7aqj6a2zgtqScwjeTKYWnaFXbReGDpeg4YNZCRA4vy8QwzKyLZjKfwb8By4P+AHwPLJJ2e68C6ii07a3lq1WaO81jMZlYEsunm4rvACRGxDEDSvsBfgHtyGVhX8ciyDdQ1BMe76sjMikA2XWeva0wIqRXAuhzF0+XMfWE9A3qVcdg+HR14zsys8LR191Fjf0fPSrobuI2kTeFckm6xu72I4IGl6zl68nB6lOZsOGszsy6jreqjzP6OXgWOS6fXA0Xxb/OL67axtmonnzzJVUdmVhzauvvoQ50ZSFf0wNKklsy3oppZschm5LXewEdIutFuuiczIj6cw7i6hLkvrGfqXv1pvsz6AAAPvklEQVQZPbhPvkMxM+sU2VSU/xrYGzgVmEsy1vLWXAbVFVTvquPJlZs9oI6ZFZVsksLkiPgKUJ32g/RvwMG5DSv/Hl2+kZr6BlcdmVlRySYp1KY/KyUdBAwCJuQsoi5i7gvr6duzlFkTiqJN3cwMyO7htWskDQG+AswB+qfT3VZE8MAL63jrvsPoVVaa73DMzDpNu0khIn6ZTs4FJuU2nK5h5YZqyjft4KJj9813KGZmnSqbvo+GSfqRpKckzZf0A0nDOiO4fHlgadIrqru2MLNik02bwi0k3VqcDZwDbABuzWVQ+Tb3hfVMGtGPcUP75jsUM7NOlU1SGBoR/xMRK9PX/wLddkzK2voGHluxkWOn+CrBzIpPNknhfknnSSpJX+8m6SW1W3p+7VZ21TX4riMzK0ptdYi3laQDPAGfAW5OV5UA24Cv5jy6PFhQUQnA9LHd9mLIzKxVbfV9NKAzA+kqFpZXMqxfT8YOcdcWZlZ8snlOAUnvBI5NZx+IiD/nLqT8WlBeyYxxg5GU71DMzDpdNrekfhP4FLAkfX0qXdbtbNlZy/L125g+zlVHZlacsrlSOAOYERENAJJuBJ4GLs1lYPnwTEUVETgpmFnRynY4scyz5KBsdy7pNElLJS2T9IYkIukzkpZIWiTpPkn7ZLvvXHi6vLGROetDNDPrVrK5UvgG8LSk+0nuRDoWuKy9jSSVAj8BTgEqgCclzYmIJRnFngZmRcR2SR8Hrgbe08Fj2GMWllcycXg/Bvftma8QzMzyqs2koKS19SHgLcDhJEnhixHxShb7PgJYFhEr0n3dAswmaZcAICLuzyj/GPD+DkW/hy2sqOSoSd26Bw8zsza1mRQiIiT9MSJmkvSQ2hFjgPKM+QrgyDbKfwS4p6UVki4CLgIYP358B8PIztqqHby6ZRcz3J5gZkUsmzaFxyQdvhv7bumezmixoPR+YBbw7ZbWR8Q1ETErImaNGJGb7icWNrYnOCmYWRHLpk3hBOBjkl4CqklO9hERh7SzXQUwLmN+LLCmeSFJJwNfAo6LiF3ZBJ0LT5dX0qNU7D9qYL5CMDPLu2ySwum7ue8ngSmSJgKrgfOA92YWkHQo8AvgtIhYt5vvs0csLK/kgFED6d3Dg+qYWfFqq++j3sDHgMnAYuBXEVGX7Y4jok7SxcC9QClwXUQ8K+lKYF5EzCGpLuoP3J4+QfxyRLxzt49mN9U3BIsrqjh75tjOfmszsy6lrSuFG0nGZ/4XydXCASRPNmctIu4G7m627PKM6ZM7sr9cWbZuG9U19e4Ez8yKXltJ4YCIOBhA0q+AJzonpM7X2Mg8Y7yTgpkVt7buPqptnOhItVEhWlBRyYDeZUwc1i/foZiZ5VVbVwrTJW1JpwX0Secb7z7qNrfpLHg56Rm1pMQ9o5pZcWtrPIWiuA1nR009S1/dysen7ZvvUMzM8i7bDvG6rWfXVFHfEH5ozcwMJwUWND3J7J5RzcycFMorGTO4DyMH9M53KGZmeVf0SWFhRaWvEszMUkWdFDZu20X5ph3uGdXMLFXUSWFhReNIa04KZmZQ5ElhQXkVJYKDxrj6yMwMij4pVDJ1rwH065VNZ7FmZt1f0SaFiGBheaXbE8zMMhRtUli1cTtVO2r90JqZWYaiTQqND635SsHM7DVFnRT69Chlysj++Q7FzKzLKOqkcPCYQZSVFu1HYGb2BkV5Rqypa2DJmi0eVMfMrJmiTArPv7KFmvoGP7RmZtZMUSYF94xqZtayok0Kw/v3YszgPvkOxcysSynKpJA8tDYIycNvmpllKrqkULWjluXrq/18gplZC4ouKSyuqALwk8xmZi0ouqTQ2F32Ib7zyMzsDYouKTz9ciWTRvRjUJ8e+Q7FzKzLKaqkEBEsKK9khq8SzMxaVFRJYW3VTjZs2+X2BDOzVhRVUnDPqGZmbSuqpLCwvJKepSVMGzUg36GYmXVJRZUUFpRXsv/ogfQqK813KGZmXVJOk4Kk0yQtlbRM0qUtrO8l6dZ0/eOSJuQqlvqGYPHqKg511ZGZWatylhQklQI/AU4HDgDOl3RAs2IfATZHxGTg+8C3chXPi+u2sr2m3p3gmZm1IZdXCkcAyyJiRUTUALcAs5uVmQ3cmE7fAZykHHVItODltGdU345qZtaqXCaFMUB5xnxFuqzFMhFRB1QBw5rvSNJFkuZJmrd+/frdCmZIv56ccsBeTBzeb7e2NzMrBmU53HdL//HHbpQhIq4BrgGYNWvWG9Zn49QD9+bUA/fenU3NzIpGLq8UKoBxGfNjgTWtlZFUBgwCNuUwJjMza0Muk8KTwBRJEyX1BM4D5jQrMwe4IJ0+B/hnROzWlYCZmb15Oas+iog6SRcD9wKlwHUR8aykK4F5ETEH+BXwa0nLSK4QzstVPGZm1r5ctikQEXcDdzdbdnnG9E7g3FzGYGZm2SuqJ5rNzKxtTgpmZtbEScHMzJo4KZiZWRMV2h2gktYDq3Zz8+HAhj0YTlfQ3Y6pux0PdL9j6m7HA93vmFo6nn0iYkR7GxZcUngzJM2LiFn5jmNP6m7H1N2OB7rfMXW344Hud0xv5nhcfWRmZk2cFMzMrEmxJYVr8h1ADnS3Y+puxwPd75i62/FA9zum3T6eompTMDOzthXblYKZmbXBScHMzJoUTVKQdJqkpZKWSbo03/G8WZJekrRY0gJJ8/Idz+6QdJ2kdZKeyVg2VNLfJb2Y/hySzxg7opXjuULS6vR7WiDpjHzG2FGSxkm6X9Jzkp6V9Kl0eUF+T20cT8F+T5J6S3pC0sL0mL6WLp8o6fH0O7o1HcKg/f0VQ5uCpFLgBeAUkoF9ngTOj4gleQ3sTZD0EjArIgr2gRtJxwLbgJsi4qB02dXApoj4Zpq8h0TEF/MZZ7ZaOZ4rgG0R8Z18xra7JI0CRkXEU5IGAPOBM4EPUoDfUxvH824K9HtKx7XvFxHbJPUAHgI+BXwGuDMibpH0c2BhRPysvf0Vy5XCEcCyiFgRETXALcDsPMdU9CLiQd440t5s4MZ0+kaSP9iC0MrxFLSIWBsRT6XTW4HnSMZWL8jvqY3jKViR2JbO9khfAZwI3JEuz/o7KpakMAYoz5ivoMB/EUi+9L9Jmi/ponwHswftFRFrIfkDBkbmOZ494WJJi9LqpYKoZmmJpAnAocDjdIPvqdnxQAF/T5JKJS0A1gF/B5YDlRFRlxbJ+pxXLElBLSwr9HqzoyPiMOB04BNp1YV1PT8D9gVmAGuB7+Y3nN0jqT/we+CSiNiS73jerBaOp6C/p4ioj4gZwFiSmpH9WyqWzb6KJSlUAOMy5scCa/IUyx4REWvSn+uAP5D8InQHr6b1vo31v+vyHM+bEhGvpn+wDcC1FOD3lNZT/x74TUTcmS4u2O+ppePpDt8TQERUAg8AbwEGS2ocXTPrc16xJIUngSlpa3xPkrGg5+Q5pt0mqV/aSIakfsDbgWfa3qpgzAEuSKcvAO7KYyxvWuOJM/UuCux7ShsxfwU8FxHfy1hVkN9Ta8dTyN+TpBGSBqfTfYCTSdpK7gfOSYtl/R0Vxd1HAOktZj8ASoHrIuKqPIe02yRNIrk6gGSc7d8W4vFI+h1wPEk3v68CXwX+CNwGjAdeBs6NiIJovG3leI4nqZII4CXg/zXWxRcCSccA/wIWAw3p4v8mqYcvuO+pjeM5nwL9niQdQtKQXEryj/5tEXFlep64BRgKPA28PyJ2tbu/YkkKZmbWvmKpPjIzsyw4KZiZWRMnBTMza+KkYGZmTZwUzMysiZOCdSpJ35B0vKQzO9pbbXo/9uOSnpb0tmbrXpI0fA/Huq2V5VdKOjmdvkRS3z35vl1V+r39Od9xWG45KVhnO5LkHvfjSO4X74iTgOcj4tCI6Oi2e0xEXB4R/0hnLwEKNiko4fOANfEvg3UKSd+WtAg4HHgU+CjwM0mXt1B2H0n3pZ2T3SdpvKQZwNXAGWl/931aeZ8+kv4q6cJ0/v1pX/MLJP0i7TjsI5K+n7HNhZK+18r+vivpqTSOEemyGySdI+mTwGjgfiV99Jem655RMtbFp1vY316S/qCk7/uFkt6aLv9Mut0zki5Jl02Q9LykX6bLfyPpZEkPK+kj/4i03BWSfi3pn+nyxmPvn8b9VBrP7Iz9Pifpp8BTwDhJb5f0aFr29rRvoMZxSJ6X9BBwVrtftBW+iPDLr055kfQn8yOSrn0fbqPcn4AL0ukPA39Mpz8I/LiVbV4CJgD/AD6QLts/3VePdP6nwAeAfiS9SDYufwQ4uIV9BvC+dPryxvcGbgDOyXjf4en0TODvGdsPbmGft5J0wgbJE6iD0u0Wp3H1B54l6b1zAlAHHEzyD9x84DqSDh5nZ3wuVwALgT4kT1OXkySrMmBgWmY4sCzddgLJ07xvyVj3IEmf/ABfTI+3d7qvKel2twF/zvfvkV+5fflKwTrTocACYBrQ1gBHRwG/Tad/DRyT5f7vAq6PiJvS+ZNITrhPKulW+CRgUkRUA/8E3iFpGklyWNzC/hpITuIAN2cRxwpgkqQfSToNaKk30RNJeuQkkg7YqtL9/iEiqiPpF/9OoLHNZGVELI6ko7ZngfsiIkiSyITMY4+IHZEMunQ/SQIW8PX0Cu0fJF0n75WWXxURj6XTbwEOAB5OP6cLgH1IvqeVEfFi+p43t3P81g2UtV/E7M1Jq35uIOmpcQNJHbzSE9BREbGjnV1k2xfLw8Dpkn6bnsQE3BgRl7VQ9pckfd48D1yf5f7bjCMiNkuaDpwKfIJkNK8PZ7Hflrp2b5TZV01DxnwDr//7bR5bAO8DRgAzI6JWyWh9vdP11c3e/+8Rcf7rgkq+N/eDU2R8pWA5FxELIunr/QWS/0j/CZwaETNaSQiPkPRkC8mJ7aEs3+pyYCNJNRHAfcA5kkZC07jC+6QxPU7Snfp7gd+1sr8SXutl8r2txLEVaOyxdjhQEhG/B74CHNZC+fuAj6flSyUNJKm6OVNSXyW93r6LjjfCz1YyVu8wkk74niSpmlqXJoQTSP77b8ljwNGSJqdx9ZU0lSRhTpS0b1ru/Fa2t27EScE6RdpIuzmtBpkWbY+P/UngQ2m1x3+QjDebrUuA3pKuTt/jyyQj1C0iGZEqs4vk20jaNja3sq9q4EBJ80mqfa5socw1wD2S7iepnnkgvQK6AWjpCuVTwAmSFpO0ERwYyfCQNwBPkNyZ9cuIeLoDx0y67V9ITvD/E8l4G78BZkmaR5Jcn29pw4hYT9Je87v0c3qM5DvaCVwE/CVtaF7VwZisALmXVCta6T3334+I+/Idy5sh6QoKdNB563p8pWBFR9JgSS8AOwo9IZjtab5SMDOzJr5SMDOzJk4KZmbWxEnBzMyaOCmYmVkTJwUzM2vy/wEfaGr2Vbr9cAAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7ff3113d1780>"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
    "source": [
     "#!!! you may need to execute this cell twice in order to see the output due to an problem with matplotlib\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
     "x = np.arange(0., 30.0)\n",
     "y = 1-(3/4)**x\n",
     "plt.plot(y)\n",
@@ -839,9 +836,9 @@
    "views": {}
   },
   "kernelspec": {
-   "display_name": "QISKitenv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "qiskitenv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -853,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update: Quantum_Cryptography2.ipynb to run on Qiskit 0.6
Add: Qiskit header
Add: The latest version of this notebook is available on https://github.com/qiskit/qiskit-tutorial
Move: Author name and link form 0.4.15 to 0.6 list in the index.ipynb