### PR TITLE
Fix math expression for correct rendering

### DIFF
--- a/tutorials/algorithms/06_grover.ipynb
+++ b/tutorials/algorithms/06_grover.ipynb
@@ -274,7 +274,7 @@
     "### State preparation\n",
     "\n",
     "A `state_preparation` argument is used to specify a quantum circuit that prepares a quantum state for the start point of the amplitude amplification.\n",
-    "By default, a circuit with $H^{\\otimes n} $ is used to prepare uniform superposition (so it will be Grover's search). The diffusion circuit of the amplitude amplification reflects `state_preparation` automatically."
+    "By default, a circuit with $H^{\\otimes n}$ is used to prepare uniform superposition (so it will be Grover's search). The diffusion circuit of the amplitude amplification reflects `state_preparation` automatically."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In [**State-preparation** section](https://qiskit.org/documentation/tutorials/algorithms/06_grover.html#State-preparation), a mathematical expression is displayed incorrectly.

### Details and comments

A space in original math expression is provoking the Sphinx to render wrongly the expression (see image below), Sphinx is generating this: ``$H^{:nbsphinx-math:`\otimes `n} $`` but should be generating this: ``:math:`H^{\otimes n}` ``  (similar to an expression at the beginning of del notebook, in [this section](https://qiskit.org/documentation/tutorials/algorithms/06_grover.html#Grover%E2%80%99s-algorithm))
(last error in the same paragraph is being provoked for the same math expression)



![image](https://user-images.githubusercontent.com/1554515/156260279-79e1f478-82ee-455d-b1e1-8618eae75247.png)


